### PR TITLE
add a Dockerfile for running a STUN server

### DIFF
--- a/stun/Dockerfile
+++ b/stun/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:15.04
+MAINTAINER Trevor Johnston <trevj@google.com>
+
+RUN apt-get update -qq
+RUN apt-get install -y rfc5766-turn-server
+
+RUN echo 'stun-only' >> /etc/turnserver.conf
+RUN echo 'TURNSERVER_ENABLED=1' >> /etc/default/rfc5766-turn-server
+
+EXPOSE 3478/udp
+CMD /usr/bin/turnserver


### PR DESCRIPTION
This adds an image for running a STUN server.

It uses `rfc5766-turn-server`, which is available in Ubuntu. Assuming you have `stunclient` from [stuntman](http://www.stunprotocol.org/) installed (the STUN client in `rfc5766-turn-server` is kinda junk):

Build:

```
cd stun/
docker build .
docker run -d -p 7000:3478/udp <image id>
```

Test:

```
trevj@trevj:~/Downloads/stunserver$ ./stunclient localhost 7000
Binding test: success
Local address: 127.0.0.1:43686
Mapped address: 172.17.42.1:48741
```
