### PR TITLE
poll control port with ping command

### DIFF
--- a/testing/run-scripts/connect-pair.py
+++ b/testing/run-scripts/connect-pair.py
@@ -6,16 +6,16 @@
 import socket
 import time
 
-first = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-first.connect(("localhost", 9000))
+getter = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+getter.connect(("localhost", 9000))
 
-second = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-second.connect(("localhost", 9010))
+giver = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+giver.connect(("localhost", 9010))
 
-first.send("GET\n")
+getter.send("GET\n")
 time.sleep(1.0)
-first_sdp = first.recv(4096)
-second.send("GIVE " + first_sdp + "\n")
+offer_sdp = getter.recv(4096)
+giver.send("GIVE " + offer_sdp + "\n")
 time.sleep(1.0)
-second_sdp = second.recv(4096)
-first.send(second_sdp)
+answer_sdp = giver.recv(4096)
+getter.send(answer_sdp)

--- a/testing/run-scripts/connect-pair.py
+++ b/testing/run-scripts/connect-pair.py
@@ -16,10 +16,10 @@ print "connecting to getter"
 getter.send("GET\n")
 time.sleep(1.0)
 offer_sdp = getter.recv(4096)
-print "connecting to giver, sending " + first_sdp
+print "connecting to giver, sending " + offer_sdp
 giver.send("GIVE " + offer_sdp + "\n")
 time.sleep(1.0)
 answer_sdp = giver.recv(4096)
-print "from giver, got " + second_sdp
+print "from giver, got " + answer_sdp
 getter.send(answer_sdp)
 print "sent to getter"

--- a/testing/run-scripts/run_copypaste.sh
+++ b/testing/run-scripts/run_copypaste.sh
@@ -67,7 +67,7 @@ function run_docker () {
 }
 
 run_docker copypaste-getter $1 -p 5900:5900 -p 9000:9000 -p 9999:9999
-run_docker copypaste-giver $2 -p 5901:5900 -p 9010:9000 -p 9998:9999
+run_docker copypaste-giver $2 -p 5901:5900 -p 9010:9000
 
 echo "Waiting 2 minutes, as it'll take at least that long."
 sleep 120

--- a/testing/run-scripts/run_copypaste.sh
+++ b/testing/run-scripts/run_copypaste.sh
@@ -69,15 +69,16 @@ function run_docker () {
 run_docker copypaste-getter $1 -p 5900:5900 -p 9000:9000 -p 9999:9999
 run_docker copypaste-giver $2 -p 5901:5900 -p 9010:9000
 
-echo "Waiting 2 minutes, as it'll take at least that long."
-sleep 120
-
-echo -n "Waiting for control port 9000 to come up"
-while netstat -lt | grep 9000 >/dev/null; do echo -n .;  sleep 1; done
+echo -n "Waiting for getter to come up"
+while ! (echo ping | nc -q 1 localhost 9000 | grep ping) > /dev/null; do echo -n .; sleep 0.5; done
 echo
 
-echo -n "Waiting for control port 9010 to come up"
-while netstat -lt | grep 9010 >/dev/null; do echo -n .;  sleep 1; done
+echo -n "Waiting for giver to come up"
+while ! (echo ping | nc -q 1 localhost 9010 | grep ping) > /dev/null; do echo -n .; sleep 0.5; done
 echo
 
+echo "Connecting pair..."
+sleep 2 # make sure nc is shutdown
 ./connect-pair.py
+
+echo "All done!"

--- a/testing/run-scripts/run_copypaste.sh
+++ b/testing/run-scripts/run_copypaste.sh
@@ -95,8 +95,8 @@ function run_docker () {
     sudo docker run $HOSTARGS $* --name $NAME -d $IMAGENAME /test/bin/load-copypaste.sh $REPO $BRANCH $RUNARGS -w
 }
 
-run_docker copypaste-getter $1 -p 5900:5900 -p 9000:9000 -p 9999:9999
-run_docker copypaste-giver $2 -p 5901:5900 -p 9010:9000
+run_docker copypaste-getter $1 $VNCOPTS1 -p 9000:9000 -p 9999:9999
+run_docker copypaste-giver $2 $VNCOPTS2 -p 9010:9000
 
 echo -n "Waiting for getter to come up"
 while ! (echo ping | nc -q 1 localhost 9000 | grep ping) > /dev/null; do echo -n .; sleep 0.5; done


### PR DESCRIPTION
`netstat` alone doesn't work, the port on the outer machine is marked as listening regardless of what the Docker instance is doing. This depends on:
https://github.com/uProxy/uproxy-lib/pull/214
