### PR TITLE
download and boot jetpack, to make firefox work

### DIFF
--- a/testing/integration/test/bin/browser.sh
+++ b/testing/integration/test/bin/browser.sh
@@ -18,6 +18,8 @@ case $BROWSER in
         ;;
     firefox)
         EXTDIR=${BASENAME}-firefoxapp
+        cd /tmp/jetpack/addon-sdk-*
+        source bin/activate
         cd $EXTDIR
         cfx run
         ;;

--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -67,6 +67,7 @@ RUN echo BROWSER=firefox >/etc/test.conf
 RUN cd /tmp ; mkdir ff ; cd ff ; wget -r -l1 --no-parent -A '$PATTERN' $URL
 RUN cd /usr/share ; tar xf /tmp/ff/*/*/*/*/*/*/*/*/*.bz2
 RUN ln -s /usr/share/firefox/firefox /usr/bin/firefox
+RUN mkdir -p /tmp/jetpack ; cd /tmp/jetpack ; wget https://ftp.mozilla.org/pub/mozilla.org/labs/jetpack/jetpack-sdk-latest.tar.gz ; tar xvzf jetpack-sdk-latest.tar.gz
 EOF
 
 }


### PR DESCRIPTION
Currently `run_copypaste.sh` won't work thanks to this issue:
https://github.com/freedomjs/freedom-for-firefox/issues/72

However, this does actually start the app!
