### PR TITLE
a script to print the throughput for downloading large files on various systems

### DIFF
--- a/flood/Dockerfile
+++ b/flood/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:15.04
+MAINTAINER Trevor Johnston <trevj@google.com>
+
+RUN apt-get update -qq
+RUN apt-get install -y nmap pv
+
+EXPOSE 1224
+
+COPY flood.sh /flood.sh
+ENTRYPOINT ["/flood.sh"]

--- a/flood/Dockerfile
+++ b/flood/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:trusty
 MAINTAINER Trevor Johnston <trevj@google.com>
 
 RUN apt-get update -qq

--- a/flood/flood.sh
+++ b/flood/flood.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: flood.sh <size of download> <max. transfer rate>"
+  echo "Examples:"
+  echo "  10MB @ 500k/sec: flood.sh 10M 500k"
+  echo "  1GB @ 1M/sec: flood.sh 1G 10M"
+  exit 1
+fi
+
+ncat -l -k -p 1224 -c "dd if=/dev/zero count=1 bs=$1 status=none | pv -q -L $2"

--- a/stun/Dockerfile
+++ b/stun/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:trusty
 MAINTAINER Trevor Johnston <trevj@google.com>
 
 RUN apt-get update -qq

--- a/testing/run-scripts/throughput_graphs.sh
+++ b/testing/run-scripts/throughput_graphs.sh
@@ -50,7 +50,7 @@ do
     /usr/bin/time -f %e --output /tmp/compare nc -X 5 -x localhost:9999 $FLOOD_IP 1224
     ELAPSED_SEC=`cat /tmp/compare`
     MB_PER_SEC=`echo "$(($FLOOD_SIZE_MB * 1024)) / $ELAPSED_SEC"|bc`
-    log "throughput (K/sec) for $browser $rel: $MB_PER_SEC"
+    log "throughput (K/sec) for $browser $ver: $MB_PER_SEC"
   done
 done
 

--- a/testing/run-scripts/throughput_graphs.sh
+++ b/testing/run-scripts/throughput_graphs.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Calculates the average throughput for downloading a large-ish
+# file via the SOCKS proxy.
+
+set -e
+
+FLOOD_SIZE_MB=25M
+FLOOD_MAX_SPEED=5M
+
+source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
+
+# Where is flood server?
+# We may need to start one, building an image if necessary.
+if ! docker ps | grep uproxy-flood >/dev/null; then
+  if ! docker images | grep uproxy/flood >/dev/null; then
+    log "building flood server image..."
+    docker build -t uproxy/flood ${BASH_SOURCE%/*}/../../flood
+  fi
+  log "starting flood server..."
+  docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$FLOOD_SIZE_MB"M $FLOOD_MAX_SPEED
+fi
+FLOOD_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
+log "using flood server at $FLOOD_IP"
+
+# TODO: add firefox
+for browser in chrome
+do
+  for ver in rel dev canary
+  do
+    log "benchmarking $browser $ver..."
+
+    for role in getter giver
+    do
+      if docker ps | grep uproxy-$role >/dev/null; then
+        log "stopping existing uproxy-$role..."
+        docker rm -f uproxy-$role > /dev/null
+      fi
+    done
+
+    pushd ${BASH_SOURCE%/*} > /dev/null
+    ./run_pair.sh -v -b dev $browser-$ver $browser-$ver
+    popd > /dev/null
+
+    # TODO: make this work on Mac...approximate code below
+    # if uname|grep Darwin > /dev/null
+    #   time -p (ncat -i 1 --proxy-type socks5 --proxy `boot2docker ip`:9999 $HOST_IP 1224 >/dev/null) 2>&1) > /tmp/compare
+    #   ELAPSED_SEC=`grep real /tmp/compare|cut -d' ' -f2`
+
+    /usr/bin/time -f %e --output /tmp/compare nc -X 5 -x localhost:9999 $FLOOD_IP 1224
+    ELAPSED_SEC=`cat /tmp/compare`
+    MB_PER_SEC=`echo "$(($FLOOD_SIZE_MB * 1024)) / $ELAPSED_SEC"|bc`
+    log "throughput (K/sec) for $browser $rel: $MB_PER_SEC"
+  done
+done
+
+# TODO: output a Google Charts API URL

--- a/testing/run-scripts/throughput_graphs.sh
+++ b/testing/run-scripts/throughput_graphs.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-FLOOD_SIZE_MB=25M
+FLOOD_SIZE_MB=25
 FLOOD_MAX_SPEED=5M
 
 source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)


### PR DESCRIPTION
Tidying this up from the coding party.

This starts a flood server on a variety of systems and outputs the throughput (just Chrome for now, until I can iron out a few little issues with Firefox).

The flood server is implemented with `ncat` and `pv` and is available as a "Docker executable". Seems like a nice little light-weight alternative to `uproxy-tcp-floodserver` which can handle multiple requests.
