### PR TITLE
some fixes for firefox, and normalise version names

### DIFF
--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -54,11 +54,11 @@ function get_firefox () {
             PATTERN='*.tar.bz2'
             ;;
         beta)
-            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/$(date +%Y/%m/%Y-%m-%e-mozilla-beta-debug)
-            PATTERN='*linux-x86_64.tar.bz2'
+            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest-beta/linux-x86_64/en-US/
+            PATTERN='*.tar.bz2'
             ;;
         canary)
-            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/$(date +%Y/%m/%Y-%m-%e-mozilla-aurora-debug)
+            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/
             PATTERN='*linux-x86_64.tar.bz2'
             ;;
         *)
@@ -67,8 +67,8 @@ function get_firefox () {
     esac
     cat <<EOF
 RUN echo BROWSER=firefox >/etc/test.conf
-RUN cd /tmp ; mkdir ff ; cd ff ; wget -r -l1 --no-parent -A '$PATTERN' $URL
-RUN cd /usr/share ; tar xf /tmp/ff/*/*/*/*/*/*/*/*/*.bz2
+RUN cd /tmp ; mkdir ff ; cd ff ; wget -r -l1 -np -nd -A '$PATTERN' $URL
+RUN cd /usr/share ; tar xf /tmp/ff/*.bz2
 RUN ln -s /usr/share/firefox/firefox /usr/bin/firefox
 RUN mkdir -p /tmp/jetpack ; cd /tmp/jetpack ; wget https://ftp.mozilla.org/pub/mozilla.org/labs/jetpack/jetpack-sdk-latest.tar.gz ; tar xvzf jetpack-sdk-latest.tar.gz
 EOF

--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -6,15 +6,7 @@
 # Usage:
 #   setup_browser.sh type version
 #    - Type: 'chrome' or 'firefox'
-#    - Version:
-#      - For Chrome:
-#        - dev
-#        - release
-#        - canary
-#      - For Firefox:
-#        - aurora
-#        - beta
-#        - release
+#    - Version: 'stable' or 'beta' or 'canary'
 
 source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
 
@@ -23,17 +15,17 @@ function get_chrome () {
   DRIVERURL=https://chromedriver.storage.googleapis.com/$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip
   
   case $1 in
-      dev|DEV)
-          URL=https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-          ;;
-      rel|release|REL|RELEASE)
+      stable)
           URL=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           ;;
-      canary|CANARY)
+      beta)
+          URL=https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+          ;;
+      canary)
           URL=https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
           ;;
       *)
-          log "Unknown chrome version $1. Options are dev, rel(ease), and canary."
+          log "Unknown chrome version $1. Options are stable, beta, and canary."
           exit 1
           ;;
   esac
@@ -57,20 +49,20 @@ EOF
 
 function get_firefox () {
     case $1 in
-        aurora)
-            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/$(date +%Y/%m/%Y-%m-%e-mozilla-aurora-debug)
-            PATTERN='*linux-x86_64.tar.bz2'
+        stable)
+            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest/linux-x86_64/en-US/
+            PATTERN='*.tar.bz2'
             ;;
         beta)
             URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/$(date +%Y/%m/%Y-%m-%e-mozilla-beta-debug)
             PATTERN='*linux-x86_64.tar.bz2'
             ;;
-        rel|release)
-            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/latest/linux-x86_64/en-US/
-            PATTERN='*.tar.bz2'
+        canary)
+            URL=https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/$(date +%Y/%m/%Y-%m-%e-mozilla-aurora-debug)
+            PATTERN='*linux-x86_64.tar.bz2'
             ;;
         *)
-            log "Unknown firefox version $1.  Options are aurora, beta, and rel(ease)."
+            log "Unknown firefox version $1. Options are stable, beta, and canary."
             ;;
     esac
     cat <<EOF
@@ -83,13 +75,13 @@ EOF
 
 }
 case $1 in
-    chr|chrome|CHROME|Chrome)
+    chrome)
         get_chrome $2
         ;;
-    ff|firefox|FIREFOX|Firefox|FireFox)
+    firefox)
         get_firefox $2
         ;;
-    lcr|lchrome|localchrome|LCR|LCHROME|LOCALCHROME)
+    localchrome)
         get_localchrome $2 $3
         ;;
     *)

--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -39,6 +39,21 @@ EOF
 }
 
 function get_localchrome () {
+    # validate the path.   
+    case $1 in
+        stable)
+            VERSION=release    
+            chrome_build_path Release
+            ;;
+        debug)
+            VERSION=debug
+            chrome_build_path Debug
+            ;;
+        *)
+            log "Unknown localchrome version $1. Options are stable and debug."
+            exit 1
+            ;;
+    esac
     # localchrome is an additional mount at runtime, into
     # /test/chrome.  Just generate a wrapper script here.
         cat <<EOF

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -13,56 +13,6 @@ source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
 BROWSER=$1
 VERSION=$2
 
-case $BROWSER in
-    chr|chrome|CHROME)
-        BROWSER=chrome
-        case $VERSION in
-            dev|DEV) VERSION=dev ;;
-            rel|release|REL|RELEASE) VERSION=rel ;;
-            canary|CANARY) VERSION=canary ;;
-            *)
-                log "Unknown version of chrome: $2.   Options are dev, rel(ease), and canary."
-                exit 1;
-                ;;
-        esac
-        ;;
-    lcr|lchrome|localchrome|LCR|LCHROME|LOCALCHROME)
-        BROWSER=localchrome
-        case $VERSION in
-            debug|dbg|d|DEBUG|DBG|D|Debug)
-                VERSION=debug
-                # validate the path.
-                chrome_build_path Debug
-                ;;
-            release|rel|r|RELEASE|REL|R|Release)
-                VERSION=release
-                # validate the path.
-                chrome_build_path Release
-                ;;
-            *)
-                log "Unknown version of localchrome: $2. Options are debug and release."
-                exit 1;
-                ;;
-        esac
-        ;;
-    ff|firefox|FF|FIREFOX)
-        BROWSER=firefox
-        case $VERSION in
-            aur|aurora|AUR|AURORA) VERSION=aurora ;;
-            beta|BETA) VERSION=beta ;;
-            rel|release|REL|RELEASE) VERSION=rel ;;
-            *)
-                log "Unknown version of firefox: $2.  Options are aurora, beta, and rel(ease)."
-                exit 1;
-                ;;
-        esac
-        ;;
-    *)
-        log "Unknown browser $1.  Options are firefox and chrome."
-        exit 1;
-        ;;
-esac
-
 DIR=/tmp/$BROWSER-$VERSION
 rm -rf $DIR
 mkdir $DIR

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -7,6 +7,8 @@
 #  Runs two instances running the dev version of chrome, connects them
 #  together, and runs a proxy.
 
+set -e
+
 source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
 
 BRANCH="-b dev"

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -24,10 +24,9 @@ function usage () {
     echo "  -k: KEEP containers after last process exits.  This is docker's --rm."
     echo "  -h, -?: this help message."
     echo
-    echo " browserspec is a pair of browser and version. Valid browsers are firefox and chrome."
-    echo "   Valid versions depend on the browser.  These are valid pairs:"
-    echo "     chrome-dev, chrome-rel, chrome-canary,"
-    echo "     firefox-aur, firefox-beta, firefox-rel"
+    echo "browserspec is a pair of browser-version."
+    echo "  Valid browsers are firefox and chrome, valid versions "
+    echo "  stable, beta, and canary, e.g. chrome-stable and firefox-beta."
     exit 1
 }
 

--- a/testing/run-scripts/throughput_graphs.sh
+++ b/testing/run-scripts/throughput_graphs.sh
@@ -34,10 +34,9 @@ fi
 FLOOD_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
 log "using flood server at $FLOOD_IP"
 
-# TODO: add firefox
-for browser in chrome
+for browser in chrome firefox
 do
-  for ver in rel dev canary
+  for ver in stable beta canary
   do
     log "benchmarking $browser $ver..."
 


### PR DESCRIPTION
This adds Firefox to `throughput_graphs.sh`.

Main change is to normalise the version names for each browser -- I chose `stable`, `beta`, and `canary` but am open to suggestions.

Turns out we currently can't proxy in Firefox 40+ but I filed a separate issue and this will be useful to investigate:
https://github.com/uProxy/uproxy/issues/1777
