### PR TITLE
release helper for uproxy-lib

### DIFF
--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -19,7 +19,7 @@ fi
 
 # Kill the current container, if any.
 # TODO: Skip this if the running container's args match.
-if docker ps | grep uproxy-flood >/dev/null; then
+if docker ps -a | grep uproxy-flood >/dev/null; then
   docker rm -f uproxy-flood > /dev/null
 fi
 

--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -24,4 +24,10 @@ if docker ps | grep uproxy-flood >/dev/null; then
 fi
 
 docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$1"M $2 > /dev/null
-docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood
+FLOOD_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
+
+# Wait until the service is actually up; because we use -d, docker wait
+# is unavailable and we must probe the port manually.
+while ! nc -z $FLOOD_IP 1224; do sleep 0.1; done
+
+echo "$FLOOD_IP"

--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+set -e
+
 # Prints the IP of a flood server, starting one if necessary.
-# TODO: restart the running container if the args differ
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: flood.sh <size of download> <max. transfer rate>"
@@ -11,10 +12,16 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 
-if ! docker ps | grep uproxy-flood >/dev/null; then
-  if ! docker images | grep uproxy/flood >/dev/null; then
-    docker build -t uproxy/flood ${BASH_SOURCE%/*}/../../flood
-  fi
-  docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$1"M $2
+# Build an image if none already exists.
+if ! docker images | grep uproxy/flood >/dev/null; then
+  docker build -t uproxy/flood ${BASH_SOURCE%/*}/../../flood
 fi
+
+# Kill the current container, if any.
+# TODO: Skip this if the running container's args match.
+if docker ps | grep uproxy-flood >/dev/null; then
+  docker rm -f uproxy-flood > /dev/null
+fi
+
+docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$1"M $2
 docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood

--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -23,5 +23,5 @@ if docker ps | grep uproxy-flood >/dev/null; then
   docker rm -f uproxy-flood > /dev/null
 fi
 
-docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$1"M $2
+docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$1"M $2 > /dev/null
 docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood

--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -23,7 +23,7 @@ if docker ps | grep uproxy-flood >/dev/null; then
   docker rm -f uproxy-flood > /dev/null
 fi
 
-docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood "$1"M $2 > /dev/null
+docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood $1 $2 > /dev/null
 FLOOD_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
 
 # Wait until the service is actually up; because we use -d, docker wait

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -34,7 +34,7 @@ known_small_md5sum = subprocess.check_output(
 print('** small download known md5sum: ' + known_small_md5sum)
 
 # Where is flood server?
-FLOOD_SIZE_MB = 16
+FLOOD_SIZE_MB = 1
 FLOOD_MAX_SPEED = '5M'
 flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
     FLOOD_MAX_SPEED], universal_newlines=True).strip()

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+import argparse
+import itertools
+import subprocess
+
+parser = argparse.ArgumentParser(
+    description='Cross-browser tests for uproxy-lib release process.')
+parser.add_argument('clone_path', help='path to pre-built uproxy-lib repo')
+args = parser.parse_args()
+
+browsers = ['chrome', 'firefox']
+versions = ['stable', 'beta', 'canary']
+
+test_url = 'http://www.example.com/'
+
+# Compute a hash of the page without using any proxy.
+match = subprocess.check_output(
+    'curl ' + test_url + ' 2>/dev/null|md5sum -|cut -d\' \' -f1',
+    shell=True,
+    universal_newlines=True).strip()
+print('** known md5sum: ' + match)
+
+# Iterate through every browser/version combination.
+results = {}
+combos = [('-'.join(x)) for x in itertools.product(browsers, versions)]
+for getter_spec, giver_spec in itertools.product(combos, combos):
+  print('** ' + getter_spec + ' <- ' + giver_spec)
+
+  passed = False
+  try:
+    # Start the relevant config, stopping the previous one if necessary.
+    # TODO: check first if running, to avoid spurious warnings
+    subprocess.call(['docker', 'rm', '-f', 'uproxy-getter', 'uproxy-giver'])
+    subprocess.call(['./run_pair.sh', '-p', args.clone_path,
+        getter_spec, giver_spec], timeout=15)
+
+    md5sum = subprocess.check_output(
+        'curl -x socks5h://localhost:9999 ' + test_url + ' 2>/dev/null|md5sum -|cut -d\' \' -f1',
+        shell=True,
+        universal_newlines=True).strip()
+    print('** md5sum: ' + md5sum)
+
+    passed = (md5sum == match)
+    print('** ' + str(passed))
+  except Exception as e:
+    print('** failure for ' + getter_spec + ' <- ' + giver_spec + ': ' + str(e))
+
+  results[getter_spec, giver_spec] = passed
+
+# Raw summary.
+print('** raw results: ' + str(results))
+
+# Markdown.
+# TODO: Output a URL to show this (requires an online Markdown viewer
+#       that accepts a GET request...couldn't find one).
+print('** markdown (rows are getter, columns the giver)')
+# emoji reference:
+#   http://www.emoji-cheat-sheet.com/
+success_emoji = ':white_check_mark:'
+failure_emoji = ':x:'
+# headers...
+headers = ['*']
+headers.extend(combos)
+print(' | '.join(headers))
+# bars... (required for Github markdown to treat this as a table)
+print('---: | ' + ' | '.join(itertools.repeat(':---:', len(combos))))
+# data...
+for getter_spec in combos:
+  cols = [getter_spec]
+  for giver_spec in combos:
+    cols.append(success_emoji if results[getter_spec, giver_spec] else failure_emoji)
+  print(' | '.join(cols))

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -36,7 +36,7 @@ print('** small download known md5sum: ' + known_small_md5sum)
 # Where is flood server?
 FLOOD_SIZE_MB = 16
 FLOOD_MAX_SPEED = '5M'
-flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB),
+flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
     FLOOD_MAX_SPEED], universal_newlines=True).strip()
 print('** using flood server at ' + str(flood_ip))
 

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -69,8 +69,8 @@ for getter_spec, giver_spec in itertools.product(combos, combos):
     passed = (small_md5sum == known_small_md5sum)
 
     # large (non-HTTP) transfer.
-    if subprocess.call(['nc', '-X', '5', '-x', 'localhost:9999',
-        flood_ip, '1224']) != 0:
+    if subprocess.call('nc -X 5 -x localhost:9999 ' + flood_ip + ' 1224 > /tmp/nc',
+        shell=True) != 0:
       raise Exception('nc failed, proxy probably did not start')
     large_md5sum = subprocess.check_output(
         'cat /tmp/nc|md5sum -|cut -d\' \' -f1',

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -1,5 +1,17 @@
 #!/usr/bin/python3
 
+# This is a major part of the uproxy-lib release process:
+#   https://github.com/uProxy/uproxy-lib
+# Currently, this performs two important tests on every
+# getter/giver combination of the stable, beta, and canary
+# releases of Chrome and Firefox:
+#  1. download http://www.example.com/, via curl
+#  2. transfer a 16MB file, via ncat
+# In both cases, the transferred data is checksummed
+# against a "known good" transfer.
+# At the end, the results are output as a table in Markdown
+# format, suitable for inclusion in Github release notes.
+
 import argparse
 import itertools
 import subprocess
@@ -15,11 +27,25 @@ versions = ['stable', 'beta', 'canary']
 test_url = 'http://www.example.com/'
 
 # Compute a hash of the page without using any proxy.
-match = subprocess.check_output(
+known_small_md5sum = subprocess.check_output(
     'curl ' + test_url + ' 2>/dev/null|md5sum -|cut -d\' \' -f1',
     shell=True,
     universal_newlines=True).strip()
-print('** known md5sum: ' + match)
+print('** small download known md5sum: ' + known_small_md5sum)
+
+# Where is flood server?
+FLOOD_SIZE_MB = 16
+FLOOD_MAX_SPEED = '5M'
+flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB),
+    FLOOD_MAX_SPEED], universal_newlines=True).strip()
+print('** using flood server at ' + str(flood_ip))
+
+subprocess.call('nc ' + flood_ip + ' 1224 > /tmp/nc', shell=True)
+known_large_md5sum = subprocess.check_output(
+    'cat /tmp/nc|md5sum -|cut -d\' \' -f1',
+    shell=True,
+    universal_newlines=True).strip()
+print('** large transfer known md5sum: ' + known_large_md5sum)
 
 # Iterate through every browser/version combination.
 results = {}
@@ -35,13 +61,25 @@ for getter_spec, giver_spec in itertools.product(combos, combos):
     subprocess.call(['./run_pair.sh', '-p', args.clone_path,
         getter_spec, giver_spec], timeout=15)
 
-    md5sum = subprocess.check_output(
+    # small HTTP download.
+    small_md5sum = subprocess.check_output(
         'curl -x socks5h://localhost:9999 ' + test_url + ' 2>/dev/null|md5sum -|cut -d\' \' -f1',
         shell=True,
         universal_newlines=True).strip()
-    print('** md5sum: ' + md5sum)
+    print('** small download md5sum: ' + small_md5sum)
+    passed = (small_md5sum == known_small_md5sum)
 
-    passed = (md5sum == match)
+    # large (non-HTTP) transfer.
+    if subprocess.call(['nc', '-X', '5', '-x', 'localhost:9999',
+        flood_ip, '1224']) != 0:
+      raise Exception('nc failed, proxy probably did not start')
+    large_md5sum = subprocess.check_output(
+        'cat /tmp/nc|md5sum -|cut -d\' \' -f1',
+        shell=True,
+        universal_newlines=True).strip()
+    print('** large transfer md5sum: ' + large_md5sum)
+    passed = passed and (large_md5sum == known_large_md5sum)
+
     print('** ' + str(passed))
   except Exception as e:
     print('** failure for ' + getter_spec + ' <- ' + giver_spec + ': ' + str(e))

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -55,8 +55,7 @@ for getter_spec, giver_spec in itertools.product(combos, combos):
 
   passed = False
   try:
-    # Start the relevant config, stopping the previous one if necessary.
-    # TODO: check first if running, to avoid spurious warnings
+    # Start the relevant config.
     subprocess.call(['docker', 'rm', '-f', 'uproxy-getter', 'uproxy-giver'])
     subprocess.call(['./run_pair.sh', '-p', args.clone_path,
         getter_spec, giver_spec], timeout=15)

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -62,6 +62,14 @@ else
     RUNARGS="$RUNARGS $REPO $BRANCH"
 fi
 
+# Kill any running giver and getter containers.
+for role in getter giver; do
+  if docker ps | grep uproxy-$role >/dev/null; then
+    echo "Stopping running uproxy-$role..."
+    docker rm -f uproxy-$role > /dev/null
+  fi
+done
+
 function make_image () {
     if [ $(docker images | tail -n +2 | awk '{print $1}' | /bin/grep uproxy/$1) == "uproxy/$1" ]
     then

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -134,4 +134,5 @@ echo "Connecting pair..."
 sleep 2 # make sure nc is shutdown
 ./connect-pair.py $CONTAINER_IP 9000 $CONTAINER_IP 9010
 
-echo "All done!"
+echo "SOCKS proxy should be available, sample command:"
+echo "  curl -x socks5h://localhost:9999 www.example.com"

--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -17,7 +17,7 @@ parser.add_argument('clone_path', help='path to pre-built uproxy-lib repo')
 args = parser.parse_args()
 
 # Where is flood server?
-flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB),
+flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
     FLOOD_MAX_SPEED], universal_newlines=True).strip()
 print('** using flood server at ' + str(flood_ip))
 

--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -32,10 +32,8 @@ for browser in browsers:
 
     result = 0
     try:
-      # Start the relevant config, stopping the previous one if necessary.
-      # TODO: check first if running, to avoid spurious warnings
-      subprocess.call(['docker', 'rm', '-f', 'uproxy-getter', 'uproxy-giver'])
       spec = browser + '-' + version
+      # Start the relevant config.
       subprocess.call(['./run_pair.sh', '-p', args.clone_path, spec, spec],
           timeout=15)
 


### PR DESCRIPTION
As part of:
https://github.com/uProxy/uproxy/issues/1745

I'm hoping this script can become the automated part of the release process for uproxy-lib. It starts by fetching a simple web page and computing its md5sum. Then, for all possible getter/giver configurations it tries to fetch the same page via the proxy, comparing each time the md5sum of the received page with the known-good md5sum. If the sum matches, that getter/giver configuration is marked as good.

In the end, outputs some markdown which we can include in release notes, e.g.:

| * | chrome-stable | chrome-beta | chrome-canary | firefox-stable | firefox-beta | firefox-canary |
| --: | :-: | :-: | :-: | :-: | :-: | :-: |
| chrome-stable | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: |
| chrome-beta | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: |
| chrome-canary | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: |
| firefox-stable | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | :x: |
| firefox-beta | :x: | :x: | :x: | :x: | :x: | :x: |
| firefox-canary | :x: | :x: | :x: | :x: | :x: | :x: |

Takes about 8 minutes to run on my 3.5GHz Xeon.
