### PR TITLE
Found a few bugs when rebuilding my localchrome outputs.

### DIFF
--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -42,12 +42,10 @@ function get_localchrome () {
     # validate the path.   
     case $1 in
         stable)
-            VERSION=release    
-            chrome_build_path Release
+            local v=$(chrome_build_path Release)
             ;;
         debug)
-            VERSION=debug
-            chrome_build_path Debug
+            local v=$(chrome_build_path Debug)
             ;;
         *)
             log "Unknown localchrome version $1. Options are stable and debug."

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -63,7 +63,7 @@ else
 fi
 
 function make_image () {
-    if [ $(docker images | tail -n +2 | awk '{print $1}' | /bin/grep uproxy/$1) == "uproxy/$1" ]
+    if [ "X$(docker images | tail -n +2 | awk '{print $1}' | /bin/grep uproxy/$1 )" == "Xuproxy/$1" ]
     then
         echo "Reusing existing image uproxy/$1"
     else


### PR DESCRIPTION
The "local v" changes eat up the output of chrome_build_path, otherwise it ends up in the generated Dockerfile, causing a build failure.  If the current image isn't in cache, we end up with a "" == "uproxy/$1" comparison, which is invalid.  So we put an X on both sides.
