### PR TITLE
a script to benchmark our obfuscators

### DIFF
--- a/testing/run-scripts/benchmark_obfuscators.py
+++ b/testing/run-scripts/benchmark_obfuscators.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+
+import argparse
+import csv
+import io
+import subprocess
+import sys
+import time
+import urllib.parse
+
+FLOOD_SIZE_MB = 64
+FLOOD_MAX_SPEED = '5M'
+
+parser = argparse.ArgumentParser(
+    description='Compare obfuscator throughput.')
+parser.add_argument('clone_path', help='path to pre-built uproxy-lib repo')
+args = parser.parse_args()
+
+# Where is flood server?
+flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
+    FLOOD_MAX_SPEED], universal_newlines=True).strip()
+print('** using flood server at ' + str(flood_ip))
+
+browser_spec = 'chrome-stable'
+# See churn pipe source for the full list.
+obfuscators = [
+  'none',
+  'caesar',
+  'encryptionShaper',
+  'sequenceShaper',
+  'protean',
+  'fragmentationShaper'
+]
+
+# Run the benchmarks.
+throughput = {}
+for obfuscator in obfuscators:
+  print('** ' + obfuscator)
+
+  result = 0
+  try:
+    # Start the relevant config.
+    run_pair = subprocess.Popen(['./run_pair.sh',
+        '-v',
+        '-p', args.clone_path,
+        browser_spec, browser_spec],
+        universal_newlines=True,
+        stdin=subprocess.PIPE)
+
+    run_pair.stdin.write('obfuscate with ' + obfuscator + '\n')
+    run_pair.stdin.close()
+    run_pair.wait(30)
+
+    # time.time is good for Unix-like systems.
+    start = time.time()
+    if subprocess.call(['nc', '-X', '5', '-x', 'localhost:9999',
+        flood_ip, '1224']) != 0:
+      raise Exception('nc failed, proxy probably did not start')
+    end = time.time()
+
+    print('** benchmarking...')
+
+    elapsed = round(end - start, 2)
+    result = int((FLOOD_SIZE_MB / elapsed) * 1000)
+
+    print('** throughput for ' + obfuscator + ': ' + str(result) + 'K/sec')
+  except Exception as e:
+    print('** failed to test ' + obfuscator + ': ' + str(e))
+
+  throughput[obfuscator] = result
+
+# Raw summary.
+print('** raw numbers: ' + str(throughput))
+
+# CSV, e.g.:
+#   obfuscator,none,caesar,protean
+#   throughput,500,300,100
+stringio = io.StringIO()
+writer = csv.writer(stringio)
+headers = ['obfuscator']
+headers.extend(obfuscators)
+writer.writerow(headers)
+figures = ['throughput']
+for obfuscator in obfuscators:
+  figures.append(throughput[obfuscator])
+writer.writerow(figures)
+print('** CSV')
+print(stringio.getvalue())
+
+# URL which uses Datacopia's oh-so-simple GET-based API:
+print('** http://www.datacopia.com/?data=' + urllib.parse.quote(
+    stringio.getvalue()))

--- a/testing/run-scripts/benchmark_transformers.py
+++ b/testing/run-scripts/benchmark_transformers.py
@@ -9,7 +9,7 @@ import time
 import urllib.parse
 
 FLOOD_SIZE_MB = 64
-FLOOD_MAX_SPEED = '5M'
+FLOOD_MAX_SPEED_MB = 5
 
 parser = argparse.ArgumentParser(
     description='Compare transformer throughput.')
@@ -18,7 +18,7 @@ args = parser.parse_args()
 
 # Where is flood server?
 flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
-    FLOOD_MAX_SPEED], universal_newlines=True).strip()
+    str(FLOOD_MAX_SPEED_MB) + 'M'], universal_newlines=True).strip()
 print('** using flood server at ' + str(flood_ip))
 
 browser_spec = 'chrome-stable'

--- a/testing/run-scripts/benchmark_transformers.py
+++ b/testing/run-scripts/benchmark_transformers.py
@@ -12,7 +12,7 @@ FLOOD_SIZE_MB = 64
 FLOOD_MAX_SPEED = '5M'
 
 parser = argparse.ArgumentParser(
-    description='Compare obfuscator throughput.')
+    description='Compare transformer throughput.')
 parser.add_argument('clone_path', help='path to pre-built uproxy-lib repo')
 args = parser.parse_args()
 
@@ -23,7 +23,7 @@ print('** using flood server at ' + str(flood_ip))
 
 browser_spec = 'chrome-stable'
 # See churn pipe source for the full list.
-obfuscators = [
+transformers = [
   'none',
   'caesar',
   'encryptionShaper',
@@ -34,8 +34,8 @@ obfuscators = [
 
 # Run the benchmarks.
 throughput = {}
-for obfuscator in obfuscators:
-  print('** ' + obfuscator)
+for transformer in transformers:
+  print('** ' + transformer)
 
   result = 0
   try:
@@ -47,7 +47,7 @@ for obfuscator in obfuscators:
         universal_newlines=True,
         stdin=subprocess.PIPE)
 
-    run_pair.stdin.write('obfuscate with ' + obfuscator + '\n')
+    run_pair.stdin.write('transform with ' + transformer + '\n')
     run_pair.stdin.close()
     run_pair.wait(30)
 
@@ -63,26 +63,26 @@ for obfuscator in obfuscators:
     elapsed = round(end - start, 2)
     result = int((FLOOD_SIZE_MB / elapsed) * 1000)
 
-    print('** throughput for ' + obfuscator + ': ' + str(result) + 'K/sec')
+    print('** throughput for ' + transformer + ': ' + str(result) + 'K/sec')
   except Exception as e:
-    print('** failed to test ' + obfuscator + ': ' + str(e))
+    print('** failed to test ' + transformer + ': ' + str(e))
 
-  throughput[obfuscator] = result
+  throughput[transformer] = result
 
 # Raw summary.
 print('** raw numbers: ' + str(throughput))
 
 # CSV, e.g.:
-#   obfuscator,none,caesar,protean
+#   transformer,none,caesar,protean
 #   throughput,500,300,100
 stringio = io.StringIO()
 writer = csv.writer(stringio)
-headers = ['obfuscator']
-headers.extend(obfuscators)
+headers = ['transformer']
+headers.extend(transformers)
 writer.writerow(headers)
 figures = ['throughput']
-for obfuscator in obfuscators:
-  figures.append(throughput[obfuscator])
+for transformer in transformers:
+  figures.append(throughput[transformer])
 writer.writerow(figures)
 print('** CSV')
 print(stringio.getvalue())

--- a/testing/run-scripts/benchmark_transformers.py
+++ b/testing/run-scripts/benchmark_transformers.py
@@ -63,7 +63,7 @@ for transformer in transformers:
     elapsed = round(end - start, 2)
     result = int((FLOOD_SIZE_MB / elapsed) * 1000)
 
-    print('** throughput for ' + transformer + ': ' + str(result) + 'K/sec')
+    print('** throughput for ' + transformer + ': ' + str(result) + 'KB/sec')
   except Exception as e:
     print('** failed to test ' + transformer + ': ' + str(e))
 

--- a/testing/run-scripts/benchmark_transformers.py
+++ b/testing/run-scripts/benchmark_transformers.py
@@ -41,7 +41,6 @@ for transformer in transformers:
   try:
     # Start the relevant config.
     run_pair = subprocess.Popen(['./run_pair.sh',
-        '-v',
         '-p', args.clone_path,
         browser_spec, browser_spec],
         universal_newlines=True,

--- a/testing/run-scripts/connect-pair.py
+++ b/testing/run-scripts/connect-pair.py
@@ -27,13 +27,9 @@ giver.setblocking(False)
 
 # Forward stdin to the getter, to allow commands such as
 # port to configure the proxy.
-# TODO: sleep is a horrible hack to prevent our messages
-#       being batched together into one packet which seems
-#       to work better than TCP_NODELAY.
 if not sys.stdin.isatty():
   for line in sys.stdin:
     getter.sendall(line + '\n')
-    time.sleep(0.5)
 
 getter.sendall('get\n')
 giver.sendall('give\n')

--- a/testing/run-scripts/connect-pair.py
+++ b/testing/run-scripts/connect-pair.py
@@ -3,6 +3,8 @@
 import argparse
 import select
 import socket
+import sys
+import time
 
 parser = argparse.ArgumentParser(description='Connect two SOCKS adventure instances.')
 parser.add_argument('getter_address', default='localhost',
@@ -22,6 +24,16 @@ getter.setblocking(False)
 giver = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 giver.connect((args.giver_address, args.giver_port))
 giver.setblocking(False)
+
+# Forward stdin to the getter, to allow commands such as
+# port to configure the proxy.
+# TODO: sleep is a horrible hack to prevent our messages
+#       being batched together into one packet which seems
+#       to work better than TCP_NODELAY.
+if not sys.stdin.isatty():
+  for line in sys.stdin:
+    getter.sendall(line + '\n')
+    time.sleep(0.5)
 
 getter.sendall('get\n')
 giver.sendall('give\n')

--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -48,7 +48,7 @@ for browser in browsers:
       result = int((FLOOD_SIZE_MB / elapsed) * 1000)
 
       print('** throughput for ' + browser + '/' + version + ': ' +
-          str(result) + 'K/sec')
+          str(result) + 'KB/sec')
     except Exception as e:
       print('** failed to test ' + browser + '/' + version + ': ' + str(e))
 

--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -9,7 +9,7 @@ import time
 import urllib.parse
 
 FLOOD_SIZE_MB = 64
-FLOOD_MAX_SPEED = '5M'
+FLOOD_MAX_SPEED_MB = 5
 
 parser = argparse.ArgumentParser(
     description='Measure SOCKS proxy throughput across browser versions.')
@@ -18,7 +18,7 @@ args = parser.parse_args()
 
 # Where is flood server?
 flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
-    FLOOD_MAX_SPEED], universal_newlines=True).strip()
+    str(FLOOD_MAX_SPEED_MB) + 'M'], universal_newlines=True).strip()
 print('** using flood server at ' + str(flood_ip))
 
 browsers = ['chrome', 'firefox']


### PR DESCRIPTION
Depends on:
https://github.com/uProxy/uproxy-lib/pull/291

Yields graphs like this:
![obfuscator benchmarks](http://hosting.datacopia.com/publish/20150924.203793.0d9434c4-4ff2-4d99-8bcc-5015793221d8.png)
