### PR TITLE
add latency to throughput measurements

### DIFF
--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -11,6 +11,7 @@ import urllib.parse
 FLOOD_SIZE_MB = 32
 FLOOD_MAX_SPEED_MB = 5
 
+# https://github.com/uProxy/uproxy-docker/pull/26
 LATENCY_MS = 150
 
 parser = argparse.ArgumentParser(

--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -8,7 +8,7 @@ import sys
 import time
 import urllib.parse
 
-FLOOD_SIZE_MB = 64
+FLOOD_SIZE_MB = 32
 FLOOD_MAX_SPEED_MB = 5
 
 LATENCY_MS = 150

--- a/testing/run-scripts/throughput.py
+++ b/testing/run-scripts/throughput.py
@@ -11,6 +11,8 @@ import urllib.parse
 FLOOD_SIZE_MB = 64
 FLOOD_MAX_SPEED_MB = 5
 
+LATENCY_MS = 150
+
 parser = argparse.ArgumentParser(
     description='Measure SOCKS proxy throughput across browser versions.')
 parser.add_argument('clone_path', help='path to pre-built uproxy-lib repo')
@@ -34,7 +36,10 @@ for browser in browsers:
     try:
       spec = browser + '-' + version
       # Start the relevant config.
-      subprocess.call(['./run_pair.sh', '-p', args.clone_path, spec, spec],
+      subprocess.call(['./run_pair.sh',
+          '-p', args.clone_path,
+          '-l', str(LATENCY_MS),
+          spec, spec],
           timeout=15)
 
       # time.time is good for Unix-like systems.


### PR DESCRIPTION
I've been wanting to add latency to our release process for some time. There are many reasons, such as:
- catch bugs and regressions in libsctp
- set expectations on transformers, e.g. who cares if a transformer can only do 1Mb/sec if libsctp limits us to 400Kb/sec anyway

Below is a subset of [WonderNetwork's world-wide latency table](https://wondernetwork.com/pings):
- To sanity check WonderNetwork's figures, I cross-referenced them with [dotcom-monitor](https://www.dotcom-tools.com/internet-backbone-latency.aspx) and my own ping times (US east coast).
- Columns (X-axis are likely giver locations, with good to excellent infrastructure and both EC2 and Digital Ocean have datacenters in each.
- Rows (Y-axis) are possible getter locations with, apparently, widely varying levels of internet connectivity.
- Lowest latency pairs in **bold**.

| city | new york | amsterdam | singapore |
| --- | --- | --- | --- |
| bangkok | 370 | 300 | **60** |
| cairo | 300 | **185** | 575 |
| chennai | 220 | 150 | **40** |
| hanoi | 350 | 400 | **225** |
| istanbul | 150 | **50** | 300 |
| jakarta | 275 | 350 | **25** |
| riyadh | 150 | **85** | 130 |
| shanghai | 300 | 350 | **110** |

Clearly, it's a bad idea to proxy between Jakarta and Amsterdam; on the other hand, Singapore has fantastic links throughout Asia. Mean is 97.5ms, median 72.5ms; minimum is Jakarta/Singapore at 25ms while Hanoi/Singapore is an outlier at 225ms...let's shoot for **150ms**, to err on the worst cases. Seems like Chrome 47+ and Firefox both manage ~0.5Mb/sec at this latency.

BTW, I haven't considered mobile.
