### PR TITLE
do not use -np for wget-ing firefox

### DIFF
--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -81,7 +81,7 @@ function get_firefox () {
     cat <<EOF
 RUN echo BROWSER=firefox >/etc/test.conf
 RUN npm install jpm -g
-RUN cd /tmp ; mkdir ff ; cd ff ; wget -r -l1 -np -nd -A '$PATTERN' $URL
+RUN cd /tmp ; mkdir ff ; cd ff ; wget -r -l1 -nd -A '$PATTERN' $URL
 # Sometimes there are >1 versions in the folder, e.g. following a release.
 RUN cd /usr/share ; ls /tmp/ff/*.bz2|sort|tail -1|xargs tar xf
 RUN ln -s /usr/share/firefox/firefox /usr/bin/firefox


### PR DESCRIPTION
Directory listings are looking weird...they seem to have changed something for the https://ftp.mozilla.org/pub/firefox/ tree specifically (higher up paths look like regular Apache directory listsings).

This makes it work.
