### PR TITLE
a script to create a cloud instance

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -10,6 +10,8 @@ COPY giverpw /
 RUN echo giver:`cat /giverpw` | chpasswd
 
 RUN addgroup getter
+RUN adduser --disabled-password --gecos 'uProxy Getter' --ingroup getter getter
+
 COPY add_getter.sh /add_getter.sh
 RUN chown root:root /add_getter.sh
 RUN chmod 700 /add_getter.sh

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -2,12 +2,16 @@ FROM ubuntu:trusty
 MAINTAINER Trevor Johnston <trevj@google.com>
 
 RUN apt-get update -qq
-RUN apt-get install -y openssh-server supervisor dnsutils
+RUN apt-get install -y openssh-server supervisor dnsutils jq
 
 RUN addgroup giver
 RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver
-COPY giverpw /
-RUN echo giver:`cat /giverpw` | chpasswd
+COPY set_giver_access.sh /
+RUN chown root:root /set_giver_access.sh
+RUN chmod 755 /set_giver_access.sh
+COPY giver-invite-code /
+RUN chmod 600 /giver-invite-code
+RUN /set_giver_access.sh /giver-invite-code
 
 RUN addgroup getter
 RUN adduser --disabled-password --gecos 'uProxy Getter' --ingroup getter getter

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -2,12 +2,18 @@ FROM ubuntu:trusty
 MAINTAINER Trevor Johnston <trevj@google.com>
 
 RUN apt-get update -qq
-RUN apt-get install -y openssh-server supervisor
+RUN apt-get install -y openssh-server supervisor dnsutils
 
 RUN addgroup giver
 RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver
 COPY giverpw /
 RUN echo giver:`cat /giverpw` | chpasswd
+
+RUN addgroup getter
+COPY add_getter.sh /add_getter.sh
+RUN chown root:root /add_getter.sh
+RUN chmod 700 /add_getter.sh
+RUN echo 'giver ALL=(ALL) NOPASSWD: /add_getter.sh' > /etc/sudoers
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:trusty
+MAINTAINER Trevor Johnston <trevj@google.com>
+
+RUN apt-get update -qq
+RUN apt-get install -y openssh-server supervisor
+
+RUN addgroup giver
+RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver
+RUN echo 'giver:giver' | chpasswd
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN mkdir -p /var/run/sshd
+
+EXPOSE 22
+CMD /usr/bin/supervisord -n

--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get install -y openssh-server supervisor
 
 RUN addgroup giver
 RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver
-RUN echo 'giver:giver' | chpasswd
+COPY giverpw /
+RUN echo giver:`cat /giverpw` | chpasswd
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/sshd/add_getter.sh
+++ b/sshd/add_getter.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+# Users testing on a LAN will want to override this with their
+# internal, non-routable IP (or, more simply, "localhost").
+# Everyone else will want their public, external, routable IP.
+# This beautiful, cross-platform one-liner gives us this.
+# Cogged from:
+#   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
+HOSTNAME=`dig +short myip.opendns.com @resolver1.opendns.com`
+
+function usage () {
+  echo "$0 [-i hostname]"
+  echo "  -i: hostname (or ip)"
+  echo "  -h, -?: this help message"
+  exit 1
+}
+
+while getopts i:h? opt; do
+  case $opt in
+    i) HOSTNAME="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+shift $((OPTIND-1))
+
+USERNAME=`cat /dev/urandom | tr -dc 'a-z' | fold -w 8 | head -n 1`
+PASSWORD=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 20 | head -n 1`
+
+adduser --disabled-password --gecos 'uProxy Getter' --ingroup getter $USERNAME
+echo $USERNAME:$PASSWORD | chpasswd
+
+INVITE="{\"host\":\"$HOSTNAME\", \"user\":\"$USERNAME\", \"pass\":\"$PASSWORD\"}"
+INVITE_CODE=`echo -n $INVITE|base64 -w 0`
+
+echo "invite: $INVITE"
+echo "invite code: $INVITE_CODE"

--- a/sshd/add_getter.sh
+++ b/sshd/add_getter.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Adds users to the getter group with a random password, outputting
+# an invite code for each. This is just for prototyping purposes
+# while we iron out issues with key-based authentication in the client.
+
 set -e
 
 # Users testing on a LAN will want to override this with their

--- a/sshd/add_getter.sh
+++ b/sshd/add_getter.sh
@@ -6,36 +6,32 @@
 
 set -e
 
-# Users testing on a LAN will want to override this with their
-# internal, non-routable IP (or, more simply, "localhost").
-# Everyone else will want their public, external, routable IP.
-# This beautiful, cross-platform one-liner gives us this.
-# Cogged from:
+# Beautiful cross-platform one-liner cogged from:
 #   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
-HOSTNAME=`dig +short myip.opendns.com @resolver1.opendns.com`
+PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
 
 function usage () {
-  echo "$0 [-i hostname]"
-  echo "  -i: hostname (or ip)"
+  echo "$0 [-d ip]"
+  echo "  -d: override the detected public IP (for development only)"
   echo "  -h, -?: this help message"
   exit 1
 }
 
-while getopts i:h? opt; do
+while getopts d:h? opt; do
   case $opt in
-    i) HOSTNAME="$OPTARG" ;;
+    d) PUBLIC_IP="$OPTARG" ;;
     *) usage ;;
   esac
 done
 shift $((OPTIND-1))
 
 USERNAME=`cat /dev/urandom | tr -dc 'a-z' | fold -w 8 | head -n 1`
-PASSWORD=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 20 | head -n 1`
+PASSWORD=`openssl rand -base64 20`
 
 adduser --disabled-password --gecos 'uProxy Getter' --ingroup getter $USERNAME
 echo $USERNAME:$PASSWORD | chpasswd
 
-INVITE="{\"host\":\"$HOSTNAME\", \"user\":\"$USERNAME\", \"pass\":\"$PASSWORD\"}"
+INVITE="{\"host\":\"$PUBLIC_IP\", \"user\":\"$USERNAME\", \"pass\":\"$PASSWORD\"}"
 INVITE_CODE=`echo -n $INVITE|base64 -w 0`
 
 echo "invite: $INVITE"

--- a/sshd/set_giver_access.sh
+++ b/sshd/set_giver_access.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Sets the giver account's password, given an invite code.
+
+set -e
+
+function usage () {
+  echo "$0 path-to-invite-code"
+  exit 1
+}
+
+if [ $# -lt 1 ]
+then
+  usage
+fi
+
+if [ ! -f $1 ]
+then
+  echo "file does not exist" 2>&1
+  exit 1
+fi
+
+INVITE=`cat $1|base64 -d`
+
+PASS=`echo $INVITE|jq -r .pass`
+# TOOD: use -e when we move to a newer version of jq
+if [ "$PASS" == "null" ]
+then
+  echo "invite code does not contain a password" 2>&1
+  exit 1
+fi
+
+echo giver:"$PASS" | chpasswd

--- a/sshd/supervisord.conf
+++ b/sshd/supervisord.conf
@@ -1,0 +1,2 @@
+[program:sshd]
+command=/usr/sbin/sshd -D

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -82,6 +82,7 @@ then
   echo "$CONTAINER_PREFIX-sshd image already exists, re-using"
 else
   TMP_DIR=/tmp/uproxy-sshd
+  rm -fR $TMP_DIR
   cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
 
   # 21 characters leaves no = at the end, which is generally easier to double click.

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -9,19 +9,28 @@ source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
 PREBUILT=
 SSHD_PORT=5000
 CONTAINER_PREFIX="uproxy"
+# Users testing on a LAN will want to override this with their
+# internal, non-routable IP (or, more simply, "localhost").
+# Everyone else will want their public, external, routable IP.
+# This beautiful, cross-platform one-liner gives us this.
+# Cogged from:
+#   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
+CLOUD_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
 
 function usage () {
-  echo "$0 [-p path] browser-version"
+  echo "$0 [-p path] [-h hostname] browser-version"
   echo "  -p: path to pre-built uproxy-lib repository"
+  echo "  -i: IP or hostname of the cloud instance"
   echo "  -h, -?: this help message"
   echo
   echo "Example browser-version: chrome-stable, firefox-canary"
   exit 1
 }
 
-while getopts p:h? opt; do
+while getopts p:i:h? opt; do
   case $opt in
     p) PREBUILT="$OPTARG" ;;
+    i) CLOUD_IP="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -67,11 +76,29 @@ remove_container cloud
 docker run --net=host $HOSTARGS --name $CONTAINER_PREFIX-cloud -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -w > /dev/null
 
 # Start a container for sshd, linked with Zork's.
+# If there is no image, bootstrap an invite code and build one.
 if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/sshd )X" == "Xuproxy/sshdX" ]
 then
   echo "$CONTAINER_PREFIX-sshd image already exists, re-using"
 else
-  docker build -t uproxy/sshd ${BASH_SOURCE%/*}/../../sshd
+  TMP_DIR=/tmp/uproxy-sshd
+  cp -R ${BASH_SOURCE%/*}/../../sshd $TMP_DIR
+
+  # 21 characters leaves no = at the end, which is generally easier to double click.
+  GIVER_PW=`openssl rand -base64 21`
+  echo -n $GIVER_PW > $TMP_DIR/giverpw
+  docker build -t uproxy/sshd $TMP_DIR
+
+  # TODO: invoke a script on the container, duplicating this code is dumb. 
+  UNENCODED_TOKEN="{\"host\":\"$CLOUD_IP\", \"user\":\"giver\", \"pass\":\"$GIVER_PW\"}"
+  if uname|grep Darwin > /dev/null
+  then
+    ENCODED_TOKEN=`echo -n $UNENCODED_TOKEN|base64`
+  else
+    ENCODED_TOKEN=`echo -n $UNENCODED_TOKEN|base64 -w 0`
+  fi
+  echo "password, for shell access: $GIVER_PW"
+  echo "invite code, for uProxy: $ENCODED_TOKEN"
 fi
 remove_container sshd
 

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -92,12 +92,7 @@ else
     # 21 characters leaves no = at the end, which is generally easier to double click.
     GIVER_PW=`openssl rand -base64 21`
     INVITE="{\"host\":\"$CLOUD_IP\", \"user\":\"giver\", \"pass\":\"$GIVER_PW\"}"
-    if uname|grep Darwin > /dev/null
-    then
-      INVITE_CODE=`echo -n $INVITE|base64`
-    else
-      INVITE_CODE=`echo -n $INVITE|base64 -w 0`
-    fi
+    INVITE_CODE=`echo -n $INVITE|base64 -w 0`
     echo "generated invite code: $INVITE_CODE"
   fi
 
@@ -106,13 +101,7 @@ else
 fi
 remove_container sshd
 
-HOST_IP=
-if uname|grep Darwin > /dev/null
-then
-  HOST_IP=`docker-machine ip default`
-else
-  HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
-fi
+HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
 docker run -d -p $SSHD_PORT:22 --name $CONTAINER_PREFIX-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
 
 # Happy, reassuring message.

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -105,7 +105,7 @@ HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
 docker run -d -p $SSHD_PORT:22 --name $CONTAINER_PREFIX-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
 
 # Happy, reassuring message.
-echo -n "Waiting for Zork to come up"
+echo -n "Waiting for Zork to come up..."
 while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
 echo "ready!"
 echo "Connect with:"

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -74,10 +74,17 @@ else
   docker build -t uproxy/sshd ${BASH_SOURCE%/*}/../../sshd
 fi
 remove_container sshd
-HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
+
+HOST_IP=
+if uname|grep Darwin > /dev/null
+then
+  HOST_IP=`docker-machine ip default`
+else
+  HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
+fi
 docker run -d -p $SSHD_PORT:22 --name $CONTAINER_PREFIX-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
 
 # Happy, reassuring message.
 echo -n "Waiting for Zork to come up"
-while ! ((echo ping ; sleep 0.5) | nc -w 1 localhost 9000 | grep ping) > /dev/null; do echo -n .; done
+while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
 echo "ready!"

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -82,7 +82,7 @@ then
   echo "$CONTAINER_PREFIX-sshd image already exists, re-using"
 else
   TMP_DIR=/tmp/uproxy-sshd
-  cp -R ${BASH_SOURCE%/*}/../../sshd $TMP_DIR
+  cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
 
   # 21 characters leaves no = at the end, which is generally easier to double click.
   GIVER_PW=`openssl rand -base64 21`

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -1,39 +1,42 @@
 #!/bin/bash
 
-# Runs Zork along with an SSH server.
+# Runs a Zork and SSH server, each in their own Docker containers.
+# The SSH server may be used to establish a secure tunnel to Zork,
+# which is configured to accept connections from localhost.
+#
+# uProxy's cloud social provider knows how to establish such a tunnel,
+# assuming sshd is running on port 5000 and that Zork is accessible
+# via the sshd server at zork:9000.
 
 set -e
 
-source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
-
 PREBUILT=
-SSHD_PORT=5000
-CONTAINER_PREFIX="uproxy"
-# Users testing on a LAN will want to override this with their
-# internal, non-routable IP (or, more simply, "localhost").
-# Everyone else will want their public, external, routable IP.
-# This beautiful, cross-platform one-liner gives us this.
-# Cogged from:
-#   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
-CLOUD_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
 INVITE_CODE=
+REFRESH=false
+# Beautiful cross-platform one-liner cogged from:
+#   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
+PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
+
+SSHD_PORT=5000
 
 function usage () {
-  echo "$0 [-p path] [-h hostname] browser-version"
+  echo "$0 [-p path] [-i invite code] [-r] [-d ip] browser-version"
   echo "  -p: path to pre-built uproxy-lib repository"
-  echo "  -i: IP or hostname of the cloud instance"
-  echo "  -t: invite code"
+  echo "  -i: invite code"
+  echo "  -r: recreate Docker images (WARNING: will invalidate invite codes)"
+  echo "  -d: override the detected public IP (for development only)"
   echo "  -h, -?: this help message"
   echo
   echo "Example browser-version: chrome-stable, firefox-canary"
   exit 1
 }
 
-while getopts p:i:t:h? opt; do
+while getopts p:i:rd:h? opt; do
   case $opt in
     p) PREBUILT="$OPTARG" ;;
-    i) CLOUD_IP="$OPTARG" ;;
-    t) INVITE_CODE="$OPTARG" ;;
+    i) INVITE_CODE="$OPTARG" ;;
+    r) REFRESH=true ;;
+    d) PUBLIC_IP="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -44,69 +47,65 @@ then
   usage
 fi
 
-function remove_container () {
-  if [ "X$(docker ps -a | tail -n +2 | awk '{print $NF}' | grep $CONTAINER_PREFIX-$1 )X" == "X$CONTAINER_PREFIX-$1X" ]
-  then
-    echo "Removing old $CONTAINER_PREFIX-$1 container..."
-    docker rm -f $CONTAINER_PREFIX-$1 > /dev/null
-  fi
-}
-
-# Build an image for Zork, if necessary.
-if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/$1 )X" == "Xuproxy/$1X" ]
+if [ $REFRESH = true ]
 then
-  echo "uproxy/$1 image already exists, re-using"
-else
+  docker rm -f uproxy-sshd || true
+  docker rm -f uproxy-zork || true
+  docker rmi uproxy/sshd || true
+  # TODO: This will fail if there are any containers using the
+  #       image, e.g. run_pair.sh. Regular cloud users won't be.
+  docker rmi uproxy/$1 || true
+fi
+
+# Start Zork, if necessary.
+if ! docker ps -a | grep uproxy-zork >/dev/null; then
+  if ! docker images | grep uproxy/$1 >/dev/null; then
     BROWSER=$(echo $1 | cut -d - -f 1)
     VERSION=$(echo $1 | cut -d - -f 2)
-    ./image_make.sh $BROWSER $VERSION
+    ${BASH_SOURCE%/*}/image_make.sh $BROWSER $VERSION
+  fi
+  HOSTARGS=
+  if [ ! -z "$PREBUILT" ]
+  then
+    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+  fi
+  RUNARGS=
+  if [ ! -z "$PREBUILT" ]
+  then
+      RUNARGS="$RUNARGS -p"
+  fi
+  docker run --restart=always --net=host  $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -w
 fi
 
-# Figure out the args for Zork and start it inside a new container.
-HOSTARGS=
-if [ ! -z "$PREBUILT" ]
-then
-  HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
-fi
+# Start sshd, if necessary.
+if ! docker ps -a | grep uproxy-sshd >/dev/null; then
+  if ! docker images | grep uproxy/sshd >/dev/null; then
+    TMP_DIR=/tmp/uproxy-sshd
+    rm -fR $TMP_DIR
+    cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
 
-RUNARGS=
-if [ ! -z "$PREBUILT" ]
-then
-    RUNARGS="$RUNARGS -p"
-fi
+    # TODO: invoke a script inside the container, this duplicates code
+    if [ -z "$INVITE_CODE" ]; then
+      GIVER_PW=`openssl rand -base64 20`
+      INVITE="{\"host\":\"$PUBLIC_IP\", \"user\":\"giver\", \"pass\":\"$GIVER_PW\"}"
+      INVITE_CODE=`echo -n $INVITE|base64 -w 0`
+    fi
 
-remove_container cloud
-docker run --net=host $HOSTARGS --name $CONTAINER_PREFIX-cloud -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -w > /dev/null
-
-# Start a container for sshd, linked with Zork's.
-# If there is no image, bootstrap an invite code and build one.
-if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/sshd )X" == "Xuproxy/sshdX" ]
-then
-  echo "$CONTAINER_PREFIX-sshd image already exists, re-using"
-else
-  TMP_DIR=/tmp/uproxy-sshd
-  rm -fR $TMP_DIR
-  cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
-
-  if [ -z "$INVITE_CODE" ]; then
-    # 21 characters leaves no = at the end, which is generally easier to double click.
-    GIVER_PW=`openssl rand -base64 21`
-    INVITE="{\"host\":\"$CLOUD_IP\", \"user\":\"giver\", \"pass\":\"$GIVER_PW\"}"
-    INVITE_CODE=`echo -n $INVITE|base64 -w 0`
-    echo "generated invite code: $INVITE_CODE"
+    echo -n $INVITE_CODE > $TMP_DIR/giver-invite-code
+    docker build -t uproxy/sshd $TMP_DIR
   fi
 
-  echo -n $INVITE_CODE > $TMP_DIR/giver-invite-code
-  docker build -t uproxy/sshd $TMP_DIR
+  # Add an /etc/hosts entry to the Zork container.
+  # Because the Zork container runs with --net=host, we can't use the
+  # regular, ever-so-slightly-more-elegant Docker notation.
+  HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
+  docker run --restart=always -d -p $SSHD_PORT:22 --name uproxy-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
+
+  echo -n "Waiting for Zork to come up..."
+  while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
+  echo "ready!"
+  if [ ! -z "$INVITE_CODE" ]
+  then
+    echo "invite code: $INVITE_CODE"
+  fi
 fi
-remove_container sshd
-
-HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
-docker run -d -p $SSHD_PORT:22 --name $CONTAINER_PREFIX-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
-
-# Happy, reassuring message.
-echo -n "Waiting for Zork to come up..."
-while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
-echo "ready!"
-echo "Connect with:"
-echo "  telnet $HOST_IP 9000"

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Runs Zork along with an SSH server.
+
+set -e
+
+source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
+
+PREBUILT=
+SSHD_PORT=5000
+CONTAINER_PREFIX="uproxy"
+
+function usage () {
+  echo "$0 [-p path] browser-version"
+  echo "  -p: path to pre-built uproxy-lib repository"
+  echo "  -h, -?: this help message"
+  echo
+  echo "Example browser-version: chrome-stable, firefox-canary"
+  exit 1
+}
+
+while getopts p:h? opt; do
+  case $opt in
+    p) PREBUILT="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ $# -lt 1 ]
+then
+  usage
+fi
+
+function remove_container () {
+  if [ "X$(docker ps -a | tail -n +2 | awk '{print $NF}' | grep $CONTAINER_PREFIX-$1 )X" == "X$CONTAINER_PREFIX-$1X" ]
+  then
+    echo "Removing old $CONTAINER_PREFIX-$1 container..."
+    docker rm -f $CONTAINER_PREFIX-$1 > /dev/null
+  fi
+}
+
+# Build an image for Zork, if necessary.
+if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/$1 )X" == "Xuproxy/$1X" ]
+then
+  echo "uproxy/$1 image already exists, re-using"
+else
+    BROWSER=$(echo $1 | cut -d - -f 1)
+    VERSION=$(echo $1 | cut -d - -f 2)
+    ./image_make.sh $BROWSER $VERSION
+fi
+
+# Figure out the args for Zork and start it inside a new container.
+HOSTARGS=
+if [ ! -z "$PREBUILT" ]
+then
+  HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+fi
+
+RUNARGS=
+if [ ! -z "$PREBUILT" ]
+then
+    RUNARGS="$RUNARGS -p"
+fi
+
+remove_container cloud
+docker run $HOSTARGS --name $CONTAINER_PREFIX-cloud -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -w > /dev/null
+
+# Start a container for sshd, linked with Zork's.
+if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/sshd )X" == "Xuproxy/sshdX" ]
+then
+  echo "$CONTAINER_PREFIX-sshd image already exists, re-using"
+else
+  docker build -t uproxy/sshd ${BASH_SOURCE%/*}/../../sshd
+fi
+remove_container sshd
+docker run -d -p $SSHD_PORT:22 --name $CONTAINER_PREFIX-sshd --link $CONTAINER_PREFIX-cloud:zork uproxy/sshd > /dev/null
+
+# Happy, reassuring message.
+echo -n "Waiting for Zork to come up"
+ZORK_CONTAINER_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' $CONTAINER_PREFIX-cloud`
+while ! ((echo ping ; sleep 0.5) | nc -w 1 $ZORK_CONTAINER_IP 9000 | grep ping) > /dev/null; do echo -n .; done
+echo "ready!"

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -88,3 +88,5 @@ docker run -d -p $SSHD_PORT:22 --name $CONTAINER_PREFIX-sshd --add-host zork:$HO
 echo -n "Waiting for Zork to come up"
 while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
 echo "ready!"
+echo "Connect with:"
+echo "  telnet $HOST_IP 9000"


### PR DESCRIPTION
This script, `run_cloud.sh`, spins up a uProxy cloud instance. Right now, that means a pair of Docker containers: one runs sshd, the other Zork. The upcoming cloud social provider knows how to contact the SSH server and establish a secure tunnel through to Zork.

Rough guide:
1. `run_cloud.sh`
2. sshd image, with scripts to manage invite codes

Pretty basic stuff right now, and not terribly use friendly -- the plan is that the cloud social provider will be able to invoke this on the user's behalf.

I'm keeping instructions here:
https://docs.google.com/document/d/1nMSwG5CJSxUMu9EwA1sjwrVUGWrUYQksmLM8JAwjp04/view
