### PR TITLE
have the uproxy-sshd container cache the hostname

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -13,6 +13,10 @@ COPY banner /
 RUN chmod 644 /banner
 RUN chown giver: /banner
 
+COPY hostname /
+RUN chmod 644 /hostname
+RUN chown giver: /hostname
+
 COPY issue_invite.sh /
 RUN chown root:root /issue_invite.sh
 RUN chmod 755 /issue_invite.sh

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -7,24 +7,19 @@
 
 set -e
 
-# Beautiful cross-platform one-liner cogged from:
-#   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
-PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
 INVITE_CODE=
 USERNAME=getter
 
 function usage () {
-  echo "$0 [-d ip] [-u username] [-i invite code]"
-  echo "  -d: override the detected public IP (for development only)"
+  echo "$0 [-u username] [-i invite code]"
   echo "  -i: invite code (if unspecified, a new invite code is generated)"
   echo "  -u: username (default: getter)"
   echo "  -h, -?: this help message"
   exit 1
 }
 
-while getopts d:i:u:h? opt; do
+while getopts i:u:h? opt; do
   case $opt in
-    d) PUBLIC_IP="$OPTARG" ;;
     i) INVITE_CODE="$OPTARG" ;;
     u) USERNAME="$OPTARG" ;;
     *) usage ;;
@@ -71,6 +66,7 @@ mkdir -p $HOMEDIR/.ssh
 cat $TMP/id_rsa.pub >> $HOMEDIR/.ssh/authorized_keys
 
 # Output the actual invite code.
+PUBLIC_IP=`cat /hostname`
 export CLOUD_INSTANCE_DETAILS=$(cat << EOF
 {
   "host":"$PUBLIC_IP",


### PR DESCRIPTION
Right now, when you're developing you always have to pass the `-d` option to `issue_invite.sh`.

What if, at container creation time, this value was cached? Then you wouldn't have to do this. We could also scan any existing container for the value and use it as a default, as we do for the server description.
