### PR TITLE
add a script for one-line install via curl

### DIFF
--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Quick and easy install via curl and wget.
+# 
+# All of the heavy lifting is done by run_cloud.sh: this
+# script just clones the uproxy-docker repo and executes
+# run_cloud.sh from there.
+#
+# Heavily based on Docker's installer at:
+#   https://get.docker.com/.
+
+set -e
+
+do_install() {
+  TMP_DIR=`mktemp -d`
+  git clone --depth 1 https://github.com/uProxy/uproxy-docker.git $TMP_DIR
+  cd $TMP_DIR/testing/run-scripts
+
+   # TODO: pass arguments, e.g. banner
+  ./run_cloud.sh firefox-stable
+}
+
+# Wrapped in a function for some protection against half-downloads.
+do_install


### PR DESCRIPTION
@jab this is what we talked about.

Super-simple, but has some of the bells and whistles from Docker's install script. This script's job: clone the uproxy-docker repo and run `run_cloud.sh`. Seems to work.
