### PR TITLE
make it easier to spot and select invite code

### DIFF
--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -153,4 +153,4 @@ fi
 
 # Output the invitation URL.
 INVITE_CODE=`docker cp uproxy-sshd:/initial-giver-invite-code -|tar xO`
-echo "invite code: https://www.uproxy.org/invite/$INVITE_CODE"
+echo -e "\nINVITE CODE URL:\nhttps://www.uproxy.org/invite/$INVITE_CODE"


### PR DESCRIPTION
currently the user has to scroll back through a bunch of cryptosoup to find the invite url, e.g.

```
..............................................ready!
invite code: https://www.uproxy.org/invite/ewogICJuZXR3
kNsb3VkIiwKICAibmV0d29ya0RhdGEiOiJZVVoMVIwdGFjWE56YWxFd1
ptTlVkbTR3TlFwbFlUTjBkbmRHTUVSeGVuSlRWemR3YVdOQ2VtTkNR
VzVaZG1KTmNrNTFWbmxKVUZvMkx6ZDNXRTEzWVVSb0x6WnFTalp
VVjBSTFZIZ3lTRTkwYVhkbkNsZFZaRFJVZVZGVFNWcDRZVkZrY1ZK
Q1UyMWlVMUl6VVd4TGRVeHZRbGRuZUdONU5XNUpjM2xQYlZvclZY
Wk9SbWh3YkZWWFRsSkhUbTlrYzJaUVpXY0tVREJMVTBST1YxQkxV
...
```

This change attempts to make it easier to spot and select the invite.

Might even be worth printing the URL in green or something, if that would still work with PuTTY?
