### PR TITLE
restrict access to zork via iptables, on cloud

### DIFF
--- a/testing/integration/test/bin/load-zork.sh
+++ b/testing/integration/test/bin/load-zork.sh
@@ -9,7 +9,8 @@ CLONEARGS=
 CLONESRC=https://github.com/uProxy/uproxy-lib.git
 PREBUILT=false
 NPM=false
-while getopts b:r:nlpvh? opt; do
+IPTABLES=false
+while getopts b:r:nlpvz:h? opt; do
     case $opt in
         b)
             CLONEARGS="$CLONEARGS -b $OPTARG"
@@ -29,14 +30,18 @@ while getopts b:r:nlpvh? opt; do
         l)
             LISTEN=true
             ;;
+        z)
+            IPTABLES=$OPTARG
+            ;;
         *)
-            echo "$0 [-b branch] [-r repo] [-n] [-l] [-p] [-v] [-h]"
+            echo "$0 [-b branch] [-r repo] [-z true|false] [-n] [-l] [-p] [-v] [-h]"
             echo "  -b: BRANCH is the branch to checkout instead of HEAD's referant."
             echo "  -r: REPO is the repository to clone instead of github.com/uProxy/uproxy-lib."
             echo "  -n: install uproxy-lib from npm (overrides -b, -r, and -p)"
             echo "  -l: wait until the extension is listening."
             echo "  -p: use a pre-built uproxy-lib repo (overrides -b and -r)."
             echo "  -v: run a vncserver (port 5900 in the instance)"
+            echo "  -z: restrict access to port 9000 via iptables (default: false)"
             echo "  -h, -?: this help message"
             exit 1;
             ;;
@@ -68,6 +73,22 @@ if [ $PREBUILT = false ]; then
         ./setup.sh install
         grunt zork
     fi
+fi
+
+if [ "$IPTABLES" = true ]
+then
+  if ! iptables -v -L INPUT|grep 9000|grep docker0 >/dev/null
+  then
+    # Restrict access to zork to connections originating from
+    # localhost and our own Docker containers. Note that doing
+    # this inside a Docker container is *VERY WEIRD* and
+    # potentially *DANGEROUS*. However, we do it on cloud
+    # because the Zork container runs with --net=host and
+    # without this, Zork's command port would remain publically
+    # accessible.
+    iptables -A INPUT -p tcp -i lo --dport 9000 -j ACCEPT
+    iptables -A INPUT -p tcp ! -i docker0 --dport 9000 -j REJECT
+  fi
 fi
 
 /usr/bin/supervisord -n -c /test/etc/supervisord-$BROWSER.conf

--- a/testing/run-scripts/gen_image.sh
+++ b/testing/run-scripts/gen_image.sh
@@ -14,7 +14,7 @@ RUN apt-get update -qq -y && apt-get install -qq -y \
   wget libav-tools xvfb unzip nodejs nodejs-dev npm \
   git default-jre vnc4server aptitude net-tools x11vnc \
   fvwm vim libpango1.0-0 libappindicator1 xdg-utils \
-  libcurl3 libgcrypt11 supervisor
+  libcurl3 libgcrypt11 supervisor iptables
 RUN npm install -g bower grunt-cli
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 LABEL date=$(date +%F)

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -124,7 +124,10 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   then
       RUNARGS="$RUNARGS -n"
   fi
-  docker run --restart=always --net=host  $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS
+  # NET_ADMIN is required to run iptables inside the container.
+  # Full list of capabilities:
+  #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
+  docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -z true
 fi
 
 # Start sshd, if necessary.


### PR DESCRIPTION
I'm not extremely happy about this. If this were a movie, I'd credit the pull request to Alan Smithee. However, it limits access to the Zork port in a reasonably safe, reliable, and portable way. Should be good enough for a slightly wider, experimental launch.

I will file an issue to fix this -- ideas include creating a special churn module for cloud which always listens on one, fixed UDP port.

@soycode you might be interested too.
