### PR TITLE
remove the X lock so docker restart works better

### DIFF
--- a/testing/integration/test/bin/load-zork.sh
+++ b/testing/integration/test/bin/load-zork.sh
@@ -48,8 +48,9 @@ while getopts b:r:nlpvz:h? opt; do
     esac
 done
 
-
 # Overlap X startup with our download and build.
+pkill Xvfb
+rm -f /tmp/.X10-lock
 export DISPLAY=:10
 Xvfb :10 -screen 0 1280x1024x24 &
 fvwm &


### PR DESCRIPTION
More spit and polish, fixing the issue where the X server doesn't restart when you:
- `docker restart uproxy-zork`
- restart docker or the host
