### PR TITLE
work around chrome startup issue with --load-and-launch-app

### DIFF
--- a/testing/integration/test/etc/supervisord-chrome.conf
+++ b/testing/integration/test/etc/supervisord-chrome.conf
@@ -1,7 +1,7 @@
 [supervisord]
 
 [program:chrome]
-command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy-lib/build/dist/samples/zork-chromeapp --no-default-browser-check --no-first-run
+command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy-lib/build/dist/samples/zork-chromeapp --silent-launch --no-default-browser-check --no-first-run
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/zork.log


### PR DESCRIPTION
Came across the `--silent-launch` switch in this issue's comment thread:
https://code.google.com/p/chromium/issues/detail?id=175381

It seems to fix the issue I've been seeing in which Chrome sometimes fails to successfully launch:
https://github.com/uProxy/uproxy/issues/2174

This will make our release script a lot less painful to run.
