### PR TITLE
add -u argument for updating cloud installs

### DIFF
--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -14,39 +14,42 @@ PREBUILT=
 NPM=true
 INVITE_CODE=
 REFRESH=false
+UPDATE=false
 PUBLIC_IP=
 BANNER=
 
 SSHD_PORT=5000
 
 function usage () {
-  echo "$0 [-p path] [-i invite code] [-r] [-d ip] [-b banner] browser-version"
-  echo "  -p: path to pre-built uproxy-lib repository"
-  echo "  -i: invite code"
-  echo "  -r: recreate Docker images (WARNING: will invalidate invite codes)"
-  echo "  -d: override the detected public IP (for development only)"
-  echo "  -b: name to use in contacts list"
-  echo "  -h, -?: this help message"
-  echo
-  echo "Example browser-version: chrome-stable, firefox-canary"
-  exit 1
+    echo "$0 [-p path] [-i invite code] [-r] [-u] [-d ip] [-b banner] browser-version"
+    echo "  -p: path to pre-built uproxy-lib repository"
+    echo "  -i: invite code"
+    echo "  -r: recreate Docker images (WARNING: will invalidate invite codes)"
+    echo "  -u: update uProxy (overrides -r)"
+    echo "  -d: override the detected public IP (for development only)"
+    echo "  -b: name to use in contacts list"
+    echo "  -h, -?: this help message"
+    echo
+    echo "Example browser-version: chrome-stable, firefox-canary"
+    exit 1
 }
 
-while getopts p:i:rd:b:h? opt; do
-  case $opt in
-    p) PREBUILT="$OPTARG" ;;
-    i) INVITE_CODE="$OPTARG" ;;
-    r) REFRESH=true ;;
-    d) PUBLIC_IP="$OPTARG" ;;
-    b) BANNER="$OPTARG" ;;
-    *) usage ;;
-  esac
+while getopts p:i:rud:b:h? opt; do
+    case $opt in
+        p) PREBUILT="$OPTARG" ;;
+        i) INVITE_CODE="$OPTARG" ;;
+        r) REFRESH=true ;;
+        u) UPDATE=true ;;
+        d) PUBLIC_IP="$OPTARG" ;;
+        b) BANNER="$OPTARG" ;;
+        *) usage ;;
+    esac
 done
 shift $((OPTIND-1))
 
 if [ $# -lt 1 ]
 then
-  usage
+    usage
 fi
 
 # Set the cloud instance's banner.
@@ -56,16 +59,16 @@ fi
 #  - server's hostname
 if [ -z "$BANNER" ]
 then
-  if docker ps -a | grep uproxy-sshd >/dev/null
-  then
-    if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
+    if docker ps -a | grep uproxy-sshd >/dev/null
     then
-      docker start uproxy-sshd > /dev/null
+        if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
+        then
+            docker start uproxy-sshd > /dev/null
+        fi
+        BANNER=`docker exec uproxy-sshd cat /banner`
+    else
+        BANNER=`hostname`
     fi
-    BANNER=`docker exec uproxy-sshd cat /banner`
-  else
-    BANNER=`hostname`
-  fi
 fi
 
 # Set the cloud instance's hostname.
@@ -75,89 +78,95 @@ fi
 #  - pull from DNS
 if [ -z "$PUBLIC_IP" ]
 then
-  if docker ps -a | grep uproxy-sshd >/dev/null
-  then
-    if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
+    if docker ps -a | grep uproxy-sshd >/dev/null
     then
-      docker start uproxy-sshd > /dev/null
+        if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
+        then
+            docker start uproxy-sshd > /dev/null
+        fi
+        # Don't fail if the current installation has no /hostname.
+        PUBLIC_IP=`docker exec uproxy-sshd cat /hostname || echo -n ""`
     fi
-    # Don't fail if the current installation has no /hostname.
-    PUBLIC_IP=`docker exec uproxy-sshd cat /hostname || echo -n ""`
-  fi
-  if [ -z "$PUBLIC_IP" ]
-  then
-    # Beautiful cross-platform one-liner cogged from:
-    #   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
-    PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
-  fi
+    if [ -z "$PUBLIC_IP" ]
+    then
+        # Beautiful cross-platform one-liner cogged from:
+        #   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
+        PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
+    fi
+fi
+
+if [ $UPDATE = true ]
+then
+    INVITE_CODE=`docker cp uproxy-sshd:/initial-giver-invite-code -|tar xO`
+    REFRESH=true  # want to remove existing containers
 fi
 
 if [ $REFRESH = true ]
 then
-  docker rm -f uproxy-sshd || true
-  docker rm -f uproxy-zork || true
-  docker rmi uproxy/sshd || true
-  # TODO: This will fail if there are any containers using the
-  #       image, e.g. run_pair.sh. Regular cloud users won't be.
-  docker rmi uproxy/$1 || true
+    docker rm -f uproxy-sshd || true
+    docker rm -f uproxy-zork || true
+    docker rmi uproxy/sshd || true
+    # TODO: This will fail if there are any containers using the
+    #       image, e.g. run_pair.sh. Regular cloud users won't be.
+    docker rmi uproxy/$1 || true
 fi
 
 # Start Zork, if necessary.
 if ! docker ps -a | grep uproxy-zork >/dev/null; then
-  if ! docker images | grep uproxy/$1 >/dev/null; then
-    BROWSER=$(echo $1 | cut -d - -f 1)
-    VERSION=$(echo $1 | cut -d - -f 2)
-    ${BASH_SOURCE%/*}/image_make.sh $BROWSER $VERSION
-  fi
-  HOSTARGS=
-  if [ ! -z "$PREBUILT" ]
-  then
-    NPM=false
-    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
-  fi
-  RUNARGS=
-  if [ ! -z "$PREBUILT" ]
-  then
-      RUNARGS="$RUNARGS -p"
-  fi
-  if [ $NPM = true ]
-  then
-      RUNARGS="$RUNARGS -n"
-  fi
-  # NET_ADMIN is required to run iptables inside the container.
-  # Full list of capabilities:
-  #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
-  docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -z true
+    if ! docker images | grep uproxy/$1 >/dev/null; then
+        BROWSER=$(echo $1 | cut -d - -f 1)
+        VERSION=$(echo $1 | cut -d - -f 2)
+        ${BASH_SOURCE%/*}/image_make.sh $BROWSER $VERSION
+    fi
+    HOSTARGS=
+    if [ ! -z "$PREBUILT" ]
+    then
+        NPM=false
+        HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+    fi
+    RUNARGS=
+    if [ ! -z "$PREBUILT" ]
+    then
+        RUNARGS="$RUNARGS -p"
+    fi
+    if [ $NPM = true ]
+    then
+        RUNARGS="$RUNARGS -n"
+    fi
+    # NET_ADMIN is required to run iptables inside the container.
+    # Full list of capabilities:
+    #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
+    docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -z true
 fi
 
 # Start sshd, if necessary.
 if ! docker ps -a | grep uproxy-sshd >/dev/null; then
-  if ! docker images | grep uproxy/sshd >/dev/null; then
-    TMP_DIR=/tmp/uproxy-sshd
-    rm -fR $TMP_DIR
-    cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
+    if ! docker images | grep uproxy/sshd >/dev/null; then
+        TMP_DIR=/tmp/uproxy-sshd
+        rm -fR $TMP_DIR
+        cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
 
-    echo -n "$BANNER" > $TMP_DIR/banner
-    echo -n "$PUBLIC_IP" > $TMP_DIR/hostname
+        echo -n "$BANNER" > $TMP_DIR/banner
+        echo -n "$PUBLIC_IP" > $TMP_DIR/hostname
 
-    # Optional build args aren't very flexible...confine the messiness here.
-    ISSUE_INVITE_ARGS=
-    if [ -n "$INVITE_CODE" ]
-    then
-      ISSUE_INVITE_ARGS="$ISSUE_INVITE_ARGS -i $INVITE_CODE"
+        # Optional build args aren't very flexible...confine the messiness here.
+        ISSUE_INVITE_ARGS=
+        if [ -n "$INVITE_CODE" ]
+        then
+            ISSUE_INVITE_ARGS="$ISSUE_INVITE_ARGS -i $INVITE_CODE"
+        fi
+        docker build --build-arg issue_invite_args="$ISSUE_INVITE_ARGS" -t uproxy/sshd $TMP_DIR
     fi
-    docker build --build-arg issue_invite_args="$ISSUE_INVITE_ARGS" -t uproxy/sshd $TMP_DIR
-  fi
 
-  # Add an /etc/hosts entry to the Zork container.
-  # Because the Zork container runs with --net=host, we can't use the
-  # regular, ever-so-slightly-more-elegant Docker notation.
-  HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
-  docker run --restart=always -d -p $SSHD_PORT:22 --name uproxy-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
+    # Add an /etc/hosts entry to the Zork container.
+    # Because the Zork container runs with --net=host, we can't use the
+    # regular, ever-so-slightly-more-elegant Docker notation.
+    HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
+    docker run --restart=always -d -p $SSHD_PORT:22 --name uproxy-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
 
-  echo -n "Waiting for Zork to come up..."
-  while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
-  echo "ready!"
+    echo -n "Waiting for Zork to come up..."
+    while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
+    echo "ready!"
 fi
 
 # Output the invitation URL.

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -68,21 +68,18 @@ then
         fi
         BANNER=`docker exec uproxy-sshd cat /banner`
     else
-        BANNER=`hostname`
-    fi
-    BANNER=`docker exec uproxy-sshd cat /banner`
-else
-    # Quickly try (timeout after two seconds) DigitalOcean's
-    # metadata API which can tell us the region in which a
-    # droplet is located:
-    #   https://developers.digitalocean.com/documentation/metadata/#metadata-api-endpoints
-    BANNER=`curl -s -m 2 http://169.254.169.254/metadata/v1/region`
-    if [ -n "$BANNER" ]
-    then
-        BANNER=`echo "$BANNER"|sed 's/ams./Amsterdam/;s/sgp./Singapore/;s/fra./Frankfurt/;s/tor./Toronto/;s/nyc./New York/;s/sfo./San Francisco/;s/lon./London/'`
-        BANNER="$BANNER (DigitalOcean)"
-    else
-        BANNER=`hostname`
+        # Quickly try (timeout after two seconds) DigitalOcean's
+        # metadata API which can tell us the region in which a
+        # droplet is located:
+        #   https://developers.digitalocean.com/documentation/metadata/#metadata-api-endpoints
+        BANNER=`curl -s -m 2 http://169.254.169.254/metadata/v1/region`
+        if [ -n "$BANNER" ]
+        then
+            BANNER=`echo "$BANNER"|sed 's/ams./Amsterdam/;s/sgp./Singapore/;s/fra./Frankfurt/;s/tor./Toronto/;s/nyc./New York/;s/sfo./San Francisco/;s/lon./London/'`
+            BANNER="$BANNER (DigitalOcean)"
+        else
+            BANNER=`hostname`
+        fi
     fi
 fi
 


### PR DESCRIPTION
Fix https://github.com/uProxy/uproxy/issues/2038 - adds a `-u` parameter that is basically just `-r` with the invite code saved. Main lines changed are around 98. Ran it twice on the same instance, first without `-u` and then with it and it returned the same invite code at the end and kept working with the same client (that had added it after the first run). Of course I ran it back to back so it didn't actually _update_ the server, just rebuilt it, but it should work for actual updates as well.

The rest of the diff is because emacs ended up being somewhat insistent on re-indenting this file. I was going to go back and fight with it but I realized that it is now actually formatted the same way as https://github.com/uProxy/uproxy-docker/blob/master/testing/integration/test/bin/load-zork.sh - so I decided to leave it as is.

I don't have strong "style" opinions, I tend towards 2 space indentation for most code but think 4 is fine for bash. My main thought is just to be consistent, so if we want to switch this back to 2 then I'll probably try to switch some of the others to 2 as well.
