### PR TITLE
report success rate only for zork sessions that GAVE access

### DIFF
--- a/testing/run-scripts/zork-stats.sh
+++ b/testing/run-scripts/zork-stats.sh
@@ -29,24 +29,28 @@ fi
 IFS="
 "
 num_sessions=0
-num_successes=0
+num_giving_attempts=0
+num_giving_successes=0
 for opening in `grep ^zork $1|grep 'new client from'`
 do
   num_sessions=$((num_sessions+1))
   # ID includes a trailing :.
   session_id=`echo $opening|cut -d" " -f 4`
-  echo -n "$session_id "
-  if grep -q -i -m 1 "^zork.*$session_id.*rtctonet connected" $1; then
-    echo "SUCCESS"
-    num_successes=$((num_successes+1))  
-  elif grep -q -i -m 1 "^zork.*$session_id.*failed to start rtctonet" $1; then
-    echo "FAILED"
-    echo "***"
-    grep $session_id $1
-    echo "***"
-  else
-    echo "unknown"
+  if grep -q -i -m 1 "^zork.*$session_id.*received command: give" $1; then
+    num_giving_attempts=$((num_giving_attempts+1))
+    echo -n "$session_id "
+    if grep -q -i -m 1 "^zork.*$session_id.*rtctonet connected" $1; then
+      echo "SUCCESS"
+      num_giving_successes=$((num_giving_successes+1))  
+    elif grep -q -i -m 1 "^zork.*$session_id.*failed to start rtctonet" $1; then
+      echo "FAILED"
+      echo "***"
+      grep $session_id $1
+      echo "***"
+    else
+      echo "unknown"
+    fi
   fi
 done
-percent_successes=`echo "scale=2;(($num_successes/$num_sessions)*100)"|bc`
-echo "$num_sessions proxying sessions, $num_successes succeeded ($percent_successes%)"
+percent_successes=`echo "scale=2;(($num_giving_successes/$num_giving_attempts)*100)"|bc`
+echo "$num_sessions proxying sessions, $num_giving_successes of $num_giving_attempts attempts to give access succeeded ($percent_successes%)"


### PR DESCRIPTION
Many sessions are just `ping` sessions so it was reporting artificially low numbers.