### PR TITLE
fix chrome startup flakiness, attempt #2

### DIFF
--- a/testing/integration/test/etc/supervisord-chrome.conf
+++ b/testing/integration/test/etc/supervisord-chrome.conf
@@ -1,7 +1,7 @@
 [supervisord]
 
 [program:chrome]
-command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy-lib/build/dist/samples/zork-chromeapp --silent-launch --no-default-browser-check --no-first-run
+command=google-chrome --user-data-dir=/tmp/chrome-data --no-default-browser-check --no-first-run && google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy-lib/build/dist/samples/zork-chromeapp
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/zork.log


### PR DESCRIPTION
So, `--silent-launch` doesn't seem to work after all:
https://github.com/uProxy/uproxy-docker/pull/48

Theorising from having read https://code.google.com/p/chromium/issues/detail?id=175381 that the app might launch fine if there were already a Chrome window open, I figured I could just have supervisor launch Chrome twice:
1. first, to load Chrome and open the "new tab" page
2. second, to load and launch the app

Amazingly, it seems to work. I just ran the release script several times with consistent results.
