### PR TITLE
cloud issue new format invites

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 MAINTAINER Trevor Johnston <trevj@google.com>
 
 RUN apt-get update -qq
-RUN apt-get install -y openssh-server supervisor dnsutils jq
+RUN apt-get install -y openssh-server supervisor dnsutils jq nodejs npm
 
 RUN addgroup giver
 RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -33,32 +33,32 @@ npm install jsurl &>/dev/null
 # Either read the supplied invite code or generate a new one.
 if [ -n "$INVITE_CODE" ]
 then
-    INVITE=`echo -n $INVITE_CODE|base64 -d`
+  INVITE=`echo -n $INVITE_CODE|base64 -d`
 
-    NETWORK_DATA=`echo $INVITE|jq -r .networkData`
-    if [ "$NETWORK_DATA" == "null" ]
-    then
-        echo "invite code does not contain networkData" 2>&1
-        exit 1
-    fi
-    ENCODED_KEY=`echo $NETWORK_DATA|jq -r .key`
-    if [ "$ENCODED_KEY" == "null" ]
-    then
-        echo "invite code does not contain a private key" 2>&1
-        exit 1
-    fi
-    echo -n $ENCODED_KEY|base64 -d > $TMP/id_rsa
-    chmod 600 $TMP/id_rsa
-    ssh-keygen -y -f $TMP/id_rsa > $TMP/id_rsa.pub
+  NETWORK_DATA=`echo $INVITE|jq -r .networkData`
+  if [ "$NETWORK_DATA" == "null" ]
+  then
+    echo "invite code does not contain networkData" 2>&1
+    exit 1
+  fi
+  ENCODED_KEY=`echo $NETWORK_DATA|jq -r .key`
+  if [ "$ENCODED_KEY" == "null" ]
+  then
+    echo "invite code does not contain a private key" 2>&1
+    exit 1
+  fi
+  echo -n $ENCODED_KEY|base64 -d > $TMP/id_rsa
+  chmod 600 $TMP/id_rsa
+  ssh-keygen -y -f $TMP/id_rsa > $TMP/id_rsa.pub
 else
-    # TODO: 2048 bits makes for really long keys so we should use
-    #       ecdsa when ssh2-streams supports it:
-    #         https://github.com/mscdex/ssh2-streams/issues/3
-    ssh-keygen -q -t rsa -b 2048 -N '' -f $TMP/id_rsa
+  # TODO: 2048 bits makes for really long keys so we should use
+  #       ecdsa when ssh2-streams supports it:
+  #         https://github.com/mscdex/ssh2-streams/issues/3
+  ssh-keygen -q -t rsa -b 2048 -N '' -f $TMP/id_rsa
 
-    # TODO: Because SSH keys are already base64-encoded, re-encoding them
-    #       like this is very inefficient.
-    ENCODED_KEY=`base64 -w 0 $TMP/id_rsa`
+  # TODO: Because SSH keys are already base64-encoded, re-encoding them
+  #       like this is very inefficient.
+  ENCODED_KEY=`base64 -w 0 $TMP/id_rsa`
 fi
 
 # Apply the credentials to the account.
@@ -68,7 +68,7 @@ cat $TMP/id_rsa.pub >> $HOMEDIR/.ssh/authorized_keys
 
 # Output the actual invite code.
 PUBLIC_IP=`cat /hostname`
-export CLOUD_INSTANCE_DETAILS="\{\"host\":\"$PUBLIC_IP\",\"user\":\"$USERNAME\",\"key\":\"$ENCODED_KEY\"\}"
+export CLOUD_INSTANCE_DETAILS="{\"host\":\"$PUBLIC_IP\",\"user\":\"$USERNAME\",\"key\":\"$ENCODED_KEY\"}"
 
 CLOUD_INSTANCE_DETAILS=`nodejs -p -e "require('jsurl').stringify('$CLOUD_INSTANCE_DETAILS');"`
 

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -28,36 +28,37 @@ done
 shift $((OPTIND-1))
 
 TMP=`mktemp -d`
+npm install jsurl &>/dev/null
 
 # Either read the supplied invite code or generate a new one.
 if [ -n "$INVITE_CODE" ]
 then
-  INVITE=`echo -n $INVITE_CODE|base64 -d`
+    INVITE=`echo -n $INVITE_CODE|base64 -d`
 
-  NETWORK_DATA=`echo $INVITE|jq -r .networkData`
-  if [ "$NETWORK_DATA" == "null" ]
-  then
-    echo "invite code does not contain networkData" 2>&1
-    exit 1
-  fi
-  ENCODED_KEY=`echo $NETWORK_DATA|jq -r .key`
-  if [ "$ENCODED_KEY" == "null" ]
-  then
-    echo "invite code does not contain a private key" 2>&1
-    exit 1
-  fi
-  echo -n $ENCODED_KEY|base64 -d > $TMP/id_rsa
-  chmod 600 $TMP/id_rsa
-  ssh-keygen -y -f $TMP/id_rsa > $TMP/id_rsa.pub
+    NETWORK_DATA=`echo $INVITE|jq -r .networkData`
+    if [ "$NETWORK_DATA" == "null" ]
+    then
+        echo "invite code does not contain networkData" 2>&1
+        exit 1
+    fi
+    ENCODED_KEY=`echo $NETWORK_DATA|jq -r .key`
+    if [ "$ENCODED_KEY" == "null" ]
+    then
+        echo "invite code does not contain a private key" 2>&1
+        exit 1
+    fi
+    echo -n $ENCODED_KEY|base64 -d > $TMP/id_rsa
+    chmod 600 $TMP/id_rsa
+    ssh-keygen -y -f $TMP/id_rsa > $TMP/id_rsa.pub
 else
-  # TODO: 2048 bits makes for really long keys so we should use
-  #       ecdsa when ssh2-streams supports it:
-  #         https://github.com/mscdex/ssh2-streams/issues/3
-  ssh-keygen -q -t rsa -b 2048 -N '' -f $TMP/id_rsa
+    # TODO: 2048 bits makes for really long keys so we should use
+    #       ecdsa when ssh2-streams supports it:
+    #         https://github.com/mscdex/ssh2-streams/issues/3
+    ssh-keygen -q -t rsa -b 2048 -N '' -f $TMP/id_rsa
 
-  # TODO: Because SSH keys are already base64-encoded, re-encoding them
-  #       like this is very inefficient.
-  ENCODED_KEY=`base64 -w 0 $TMP/id_rsa`
+    # TODO: Because SSH keys are already base64-encoded, re-encoding them
+    #       like this is very inefficient.
+    ENCODED_KEY=`base64 -w 0 $TMP/id_rsa`
 fi
 
 # Apply the credentials to the account.
@@ -67,18 +68,8 @@ cat $TMP/id_rsa.pub >> $HOMEDIR/.ssh/authorized_keys
 
 # Output the actual invite code.
 PUBLIC_IP=`cat /hostname`
-export CLOUD_INSTANCE_DETAILS=$(cat << EOF
-{
-  "host":"$PUBLIC_IP",
-  "user":"$USERNAME",
-  "key":"$ENCODED_KEY"
-}
-EOF
-)
+export CLOUD_INSTANCE_DETAILS="\{\"host\":\"$PUBLIC_IP\",\"user\":\"$USERNAME\",\"key\":\"$ENCODED_KEY\"\}"
 
-echo|base64 -w 0 << EOF
-{
-  "networkName":"Cloud",
-  "networkData":"`echo -n $CLOUD_INSTANCE_DETAILS|sed s/'"'/'\\\\"'/g`"
-}
-EOF
+CLOUD_INSTANCE_DETAILS=`nodejs -p -e "require('jsurl').stringify('$CLOUD_INSTANCE_DETAILS');"`
+
+echo "v=2&networkName=Cloud&networkData=$CLOUD_INSTANCE_DETAILS&userName=$USERNAME"

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -15,7 +15,7 @@ function usage () {
   echo "$0 [-u username] [-i invite code] [-c]"
   echo "  -i: invite code (if unspecified, a new invite code is generated)"
   echo "  -u: username (default: getter)"
-  echo "  -c: output complete invite URL params (for use with cloud)"
+  echo "  -c: output complete invite URL (for manual installs)"
   echo "  -h, -?: this help message"
   exit 1
 }
@@ -72,11 +72,11 @@ cat $TMP/id_rsa.pub >> $HOMEDIR/.ssh/authorized_keys
 PUBLIC_IP=`cat /hostname`
 export CLOUD_INSTANCE_DETAILS="{\"host\":\"$PUBLIC_IP\",\"user\":\"$USERNAME\",\"key\":\"$ENCODED_KEY\"}"
 
-if [ "$COMPLETE" = true]
+if [ "$COMPLETE" = true ]
 then
   npm install jsurl &>/dev/null
   CLOUD_INSTANCE_DETAILS=`nodejs -p -e "require('jsurl').stringify('$CLOUD_INSTANCE_DETAILS');"`
-  echo "v=2&networkName=Cloud&networkData=$CLOUD_INSTANCE_DETAILS&userName=$USERNAME"
+  echo "https://www.uproxy.org/invite/?v=2&networkName=Cloud&networkData=$CLOUD_INSTANCE_DETAILS"
 else
   echo $CLOUD_INSTANCE_DETAILS
 fi

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -175,7 +175,7 @@ if ! docker ps -a | grep uproxy-sshd >/dev/null; then
         echo -n "$PUBLIC_IP" > $TMP_DIR/hostname
 
         # Optional build args aren't very flexible...confine the messiness here.
-        ISSUE_INVITE_ARGS=
+        ISSUE_INVITE_ARGS="-c"
         if [ -n "$INVITE_CODE" ]
         then
             ISSUE_INVITE_ARGS="$ISSUE_INVITE_ARGS -i $INVITE_CODE"

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -196,4 +196,4 @@ fi
 
 # Output the invitation URL.
 INVITE_CODE=`docker cp uproxy-sshd:/initial-giver-invite-code -|tar xO`
-echo -e "\nINVITE CODE URL:\nhttps://www.uproxy.org/invite/$INVITE_CODE"
+echo -e "\nINVITE CODE URL:\n$INVITE_CODE"


### PR DESCRIPTION
Fix https://github.com/uProxy/uproxy/issues/2215

@trevj as FYI, but assigning to @dborkan since I mentioned it to him earlier.

The relevant diffs are the Dockerfile and line 31 and the bottom lines of issue_invite.sh - the rest are my editors opinion about tabs in bash scripts (which does make it more consistent with other bash scripts in this repo).

The approach is hacky but it does work (i.e. I tested it successfully on Linode). It gives results like this (no longer running this server so the invite doesn't work):
https://www.uproxy.org/invite/v=2&networkName=Cloud&networkData=~'*7b*22host*22*3a*2245.79.129.96*22*2c*22user*22*3a*22giver*22*2c*22key*22*3a*22LS0tLS1CRU...&userName=giver

The length of the generated URL was ~2400 characters - an improvement over 3000, but not sub-2000.
