### PR TITLE
getting the Ubuntu band back together

### DIFF
--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -38,6 +38,17 @@ do_install() {
     echo "Docker not found, running Docker installer."
     curl -fsSL https://get.docker.com/ | sh
   fi
+  # We depend on --build-arg, introduced in Docker 1.9.
+  # Some distros are really slow to update.
+  if [ `docker version --format '{{.Server.Version}}' | cut -d . -f 2` -lt 9 ]
+  then
+    echo "Before running this script, please upgrade Docker to version 1.9 or"
+    echo "greater. If you have containers or images you wish to use afterwards,"
+    echo "read this page first:"
+    echo "  https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration"
+    exit 1
+  fi
+
   for dep in git nc
   do
     if ! command_exists $dep

--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -16,10 +16,22 @@ command_exists() {
 }
 
 do_install() {
+  # uProxy requires Docker. If it's not installed and we think the
+  # installer is likely to succeed, run the Docker installer first.
+  # Note: Because this installer is run via curl | sh, it's not
+  #       possible to ask the user for confirmation.
   if ! command_exists docker
   then
+    if [ "$USER" != "root" ]
+    then
+      echo "uProxy requires Docker. Before running this script, please "
+      echo "follow the installation instructions for your system:"
+      echo "  https://docs.docker.com/mac/started/"
+      exit 1
+    fi
+    echo "Docker not found, running Docker installer."
     curl -fsSL https://get.docker.com/ | sh
-fi
+  fi
 
   TMP_DIR=`mktemp -d`
   git clone --depth 1 https://github.com/uProxy/uproxy-docker.git $TMP_DIR

--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -11,13 +11,16 @@
 
 set -e
 
+REQUIRED_COMMANDS="docker git nc"
+
 command_exists() {
   command -v "$@" > /dev/null 2>&1
 }
 
 show_deps() {
-  echo "Before running this script, please install git, nc, and Docker."
-  echo "Installation instructions for Docker can be found here:"
+  echo "This script depends on the following commands: $REQUIRED_COMMANDS"
+  echo "Please install them before running this script. Instructions"
+  echo "for installing Docker can be found here:"
   echo "  https://docs.docker.com/mac/started/"
   exit 1
 }
@@ -49,13 +52,14 @@ do_install() {
     exit 1
   fi
 
-  for dep in git nc
+  for dep in $REQUIRED_COMMANDS
   do
     if ! command_exists $dep
     then
       show_deps
     fi
   done
+  exit 1
 
   TMP_DIR=`mktemp -d`
   git clone --depth 1 https://github.com/uProxy/uproxy-docker.git $TMP_DIR

--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -11,27 +11,16 @@
 
 set -e
 
-if [ -f /etc/centos-release ]
-then 
-  yum update -y
-  yum install -y git bind-utils nmap-ncat
-  if [ ! -f /usr/bin/docker ]
-  then
-    curl -fsSL https://get.docker.com/ | sh
-    service docker start
-  elif [ -f /usr/bin/docker -a $(( $(docker --version | cut -d . -f 2) < 10 )) ]
-  then
-    echo "Installed version of docker is too old.  Please upgrade it yourself, or remove"
-    echo "it (yum erase docker) and run this script again.  If you don't have other"
-    echo "docker containers/images, removing it is fine, this script can do the rest. If"
-    echo "you do have other docker containers/images, have a look here:"
-    echo " https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration"
-    echo "first, and then upgrade docker yourself before running this script again."
-    exit 1
-  fi
-fi
+command_exists() {
+  command -v "$@" > /dev/null 2>&1
+}
 
 do_install() {
+  if ! command_exists docker
+  then
+    curl -fsSL https://get.docker.com/ | sh
+fi
+
   TMP_DIR=`mktemp -d`
   git clone --depth 1 https://github.com/uProxy/uproxy-docker.git $TMP_DIR
   cd $TMP_DIR/testing/run-scripts


### PR DESCRIPTION
OK. Did a bunch of snooping and I think we can get back to Ubuntu.

Useful info:
- This page tells us which common distributions have fixed the issue (search for the last occurrence of **LATEST QUICK WORKAROUNDS**): https://github.com/docker/docker/issues/18180
- This page tells us that Ubuntu fixed the issue in **3.13.0.78**: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1533043

Right now, new Ubuntu 14.04 droplets on DigitalOcean have 3.13.0.79 while the Docker slug gets 3.13.0.77. **So if we ask users to install stock 14.04 and install Docker for them then we can get back onto Ubuntu.**

I would change the [blog post](https://blog.uproxy.org/2016/02/get-access-24x7-through-your-own-uproxy.html) wording to read:

> Under _Choose an image_, select _Ubuntu_, then _14.04.4 x64_ from the dropdown. Note: When a new version of Ubuntu is released, DigitalOcean will update this accordingly, so if you see e.g. _Ubuntu 14.04.5_ instead, you should choose that option.

I still don't like the idea of us installing a service like Docker...but am not aware of any other option, for an easy install (updating the kernel image on DigitalOcean boxes turns out to be an...experience - plus having to reboot the machine is a major hassle).
