### PR TITLE
auth cleanup, including authorzed_keys migration

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -6,8 +6,13 @@ RUN apt-get install -y openssh-server supervisor dnsutils jq nodejs npm
 
 RUN addgroup giver
 RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver
+RUN mkdir -p /home/giver/.ssh && chown -R giver: /home/giver/.ssh
+RUN touch /home/giver/.ssh/authorized_keys && chown giver: /home/giver/.ssh/authorized_keys
+
 RUN addgroup getter
 RUN adduser --disabled-password --gecos 'uProxy Getter' --ingroup getter getter
+RUN mkdir -p /home/getter/.ssh && chown -R getter: /home/getter/.ssh
+RUN touch /home/getter/.ssh/authorized_keys && chown getter: /home/getter/.ssh/authorized_keys
 
 COPY banner /
 RUN chmod 644 /banner
@@ -22,9 +27,6 @@ RUN chown root:root /issue_invite.sh
 RUN chmod 755 /issue_invite.sh
 # http://ubuntuforums.org/showthread.php?t=1132821
 RUN echo 'giver ALL=(root)NOPASSWD:/issue_invite.sh "",/issue_invite.sh -d *' > /etc/sudoers
-
-ARG issue_invite_args
-RUN /issue_invite.sh -u giver $issue_invite_args > /initial-giver-invite-code
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 


### PR DESCRIPTION
Bunch of things here, sorry:
 * migrate `authorized_keys` files between installs
 * do not store private keys on the server (I see this moving to the cloud social provider)
 * run `issue_invite.sh` via `docker exec`

This removes a bunch of complexity, e.g. running `issue_invite.sh` as part of the Dockerfile - yuck!