### PR TITLE
lock down SSH access to the server

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -28,6 +28,9 @@ RUN chmod 755 /issue_invite.sh
 # http://ubuntuforums.org/showthread.php?t=1132821
 RUN echo 'giver ALL=(root)NOPASSWD:/issue_invite.sh "",/issue_invite.sh -d *' > /etc/sudoers
 
+COPY login.sh /
+RUN chown root:root /login.sh && chmod 755 /login.sh
+
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 RUN mkdir -p /var/run/sshd

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -51,12 +51,12 @@ then
   fi
   echo -n $ENCODED_KEY|base64 -d > $TMP/id_rsa
   chmod 600 $TMP/id_rsa
-  ssh-keygen -y -f $TMP/id_rsa > $TMP/id_rsa.pub
+  ssh-keygen -C "$USERNAME" -y -f $TMP/id_rsa > $TMP/id_rsa.pub
 else
   # TODO: 2048 bits makes for really long keys so we should use
   #       ecdsa when ssh2-streams supports it:
   #         https://github.com/mscdex/ssh2-streams/issues/3
-  ssh-keygen -q -t rsa -b 2048 -N '' -f $TMP/id_rsa
+  ssh-keygen -C "$USERNAME" -q -t rsa -b 2048 -N '' -f $TMP/id_rsa
 
   # TODO: Because SSH keys are already base64-encoded, re-encoding them
   #       like this is very inefficient.

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -65,7 +65,7 @@ fi
 
 # Apply the credentials to the account, with access restrictions.
 # man sshd for the complete list of authorized_keys options.
-KEY_OPTS='permitopen="zork:9000",no-agent-forwarding,no-pty,no-user-rc,no-X11-forwarding'
+KEY_OPTS='command="/login.sh",permitopen="zork:9000",no-agent-forwarding,no-pty,no-user-rc,no-X11-forwarding'
 HOMEDIR=`getent passwd $USERNAME | cut -d: -f6`
 mkdir -p $HOMEDIR/.ssh
 echo "$KEY_OPTS" `cat $TMP/id_rsa.pub` >> $HOMEDIR/.ssh/authorized_keys

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -63,10 +63,12 @@ else
   ENCODED_KEY=`base64 -w 0 $TMP/id_rsa`
 fi
 
-# Apply the credentials to the account.
+# Apply the credentials to the account, with access restrictions.
+# man sshd for the complete list of authorized_keys options.
+KEY_OPTS='permitopen="zork:9000"'
 HOMEDIR=`getent passwd $USERNAME | cut -d: -f6`
 mkdir -p $HOMEDIR/.ssh
-cat $TMP/id_rsa.pub >> $HOMEDIR/.ssh/authorized_keys
+echo "$KEY_OPTS" `cat $TMP/id_rsa.pub` >> $HOMEDIR/.ssh/authorized_keys
 
 # Output the actual invite code.
 PUBLIC_IP=`cat /hostname`

--- a/sshd/issue_invite.sh
+++ b/sshd/issue_invite.sh
@@ -65,7 +65,7 @@ fi
 
 # Apply the credentials to the account, with access restrictions.
 # man sshd for the complete list of authorized_keys options.
-KEY_OPTS='permitopen="zork:9000"'
+KEY_OPTS='permitopen="zork:9000",no-agent-forwarding,no-pty,no-user-rc,no-X11-forwarding'
 HOMEDIR=`getent passwd $USERNAME | cut -d: -f6`
 mkdir -p $HOMEDIR/.ssh
 echo "$KEY_OPTS" `cat $TMP/id_rsa.pub` >> $HOMEDIR/.ssh/authorized_keys

--- a/sshd/login.sh
+++ b/sshd/login.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Run on login, via the command option in authorized_keys.
+
+# Report the server description.
+if [ "$SSH_ORIGINAL_COMMAND" == "cat /banner" ]
+then
+  cat /banner
+else
+  echo "unrecognised command"
+  exit 1
+fi


### PR DESCRIPTION
Three big things:
 * allow tunnels be established only to zork:9000
 * disable X11 forwearding, PTY creation, etc.
 * restrict command access to `/login.sh`, a new file

I believe this addresses https://github.com/uProxy/uproxy/issues/2289.