### PR TITLE
switch bash files to all use 2-space indenting

### DIFF
--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -64,7 +64,7 @@ do_install() {
   git clone --depth 1 https://github.com/uProxy/uproxy-docker.git $TMP_DIR
   cd $TMP_DIR/testing/run-scripts
 
-   # TODO: pass arguments, e.g. banner
+  # TODO: pass arguments, e.g. banner
   ./run_cloud.sh firefox-stable
 }
 

--- a/testing/integration/test/bin/load-zork.sh
+++ b/testing/integration/test/bin/load-zork.sh
@@ -11,41 +11,41 @@ PREBUILT=false
 NPM=false
 IPTABLES=false
 while getopts b:r:nlpvz:h? opt; do
-    case $opt in
-        b)
-            CLONEARGS="$CLONEARGS -b $OPTARG"
-            ;;
-        r)
-            CLONESRC=$OPTARG
-            ;;
-        p)
-            PREBUILT=true
-            ;;
-        n)
-            NPM=true
-            ;;
-        v)
-            RUNVNC=true
-            ;;
-        l)
-            LISTEN=true
-            ;;
-        z)
-            IPTABLES=$OPTARG
-            ;;
-        *)
-            echo "$0 [-b branch] [-r repo] [-z true|false] [-n] [-l] [-p] [-v] [-h]"
-            echo "  -b: BRANCH is the branch to checkout instead of HEAD's referant."
-            echo "  -r: REPO is the repository to clone instead of github.com/uProxy/uproxy-lib."
-            echo "  -n: install uproxy-lib from npm (overrides -b, -r, and -p)"
-            echo "  -l: wait until the extension is listening."
-            echo "  -p: use a pre-built uproxy-lib repo (overrides -b and -r)."
-            echo "  -v: run a vncserver (port 5900 in the instance)"
-            echo "  -z: restrict access to port 9000 via iptables (default: false)"
-            echo "  -h, -?: this help message"
-            exit 1;
-            ;;
-    esac
+  case $opt in
+    b)
+      CLONEARGS="$CLONEARGS -b $OPTARG"
+      ;;
+    r)
+      CLONESRC=$OPTARG
+      ;;
+    p)
+      PREBUILT=true
+      ;;
+    n)
+      NPM=true
+      ;;
+    v)
+      RUNVNC=true
+      ;;
+    l)
+      LISTEN=true
+      ;;
+    z)
+      IPTABLES=$OPTARG
+      ;;
+    *)
+      echo "$0 [-b branch] [-r repo] [-z true|false] [-n] [-l] [-p] [-v] [-h]"
+      echo "  -b: BRANCH is the branch to checkout instead of HEAD's referant."
+      echo "  -r: REPO is the repository to clone instead of github.com/uProxy/uproxy-lib."
+      echo "  -n: install uproxy-lib from npm (overrides -b, -r, and -p)"
+      echo "  -l: wait until the extension is listening."
+      echo "  -p: use a pre-built uproxy-lib repo (overrides -b and -r)."
+      echo "  -v: run a vncserver (port 5900 in the instance)"
+      echo "  -z: restrict access to port 9000 via iptables (default: false)"
+      echo "  -h, -?: this help message"
+      exit 1;
+      ;;
+  esac
 done
 
 # Overlap X startup with our download and build.
@@ -56,24 +56,24 @@ Xvfb :10 -screen 0 1280x1024x24 &
 fvwm &
 
 if [ $RUNVNC = true ]; then
-    x11vnc -display :10 -forever &
+  x11vnc -display :10 -forever &
 fi
 
 if [ $PREBUILT = false ]; then
-    mkdir -p /test/src
-    cd /test/src
-    if [ $NPM = true ]; then
-        npm install --prefix /test/src uproxy-lib
-        ln -s /test/src/node_modules/uproxy-lib /test/src/uproxy-lib
-        cd uproxy-lib
-    else
-        npm install -g bower grunt-cli
-        echo git clone $CLONEARGS $CLONESRC
-        git clone $CLONEARGS $CLONESRC
-        cd uproxy-lib
-        ./setup.sh install
-        grunt zork
-    fi
+  mkdir -p /test/src
+  cd /test/src
+  if [ $NPM = true ]; then
+    npm install --prefix /test/src uproxy-lib
+    ln -s /test/src/node_modules/uproxy-lib /test/src/uproxy-lib
+    cd uproxy-lib
+  else
+    npm install -g bower grunt-cli
+    echo git clone $CLONEARGS $CLONESRC
+    git clone $CLONEARGS $CLONESRC
+    cd uproxy-lib
+    ./setup.sh install
+    grunt zork
+  fi
 fi
 
 if [ "$IPTABLES" = true ]

--- a/testing/integration/test/bin/run-freedom-tests.sh
+++ b/testing/integration/test/bin/run-freedom-tests.sh
@@ -20,9 +20,9 @@ function reset_test () {
 }
 
 function setup_environment() {
-   export DISPLAY=:10
-   Xvfb :10 -screen 0 1280x1024x24 &
-   sleep 3  # let Xvfb start up
+  export DISPLAY=:10
+  Xvfb :10 -screen 0 1280x1024x24 &
+  sleep 3  # let Xvfb start up
 }
 
 setup_environment
@@ -35,17 +35,17 @@ do
   TRIES=1
   SUCCEEDED=0
   while ((TRIES < 3 && SUCCEEDED == 0)); do
-      if build_and_test $i
-	    then
-	        SUCCEEDED=1
-	    else
-	        TRIES=$((TRIES + 1))
-	        reset_test $i
-	    fi
+    if build_and_test $i
+    then
+      SUCCEEDED=1
+    else
+      TRIES=$((TRIES + 1))
+      reset_test $i
+    fi
   done
   if ((SUCCEEDED == 0)); then
-	   echo "FAILED ON $REPO AFTER 3 TRIES"
-	   exit 1
+    echo "FAILED ON $REPO AFTER 3 TRIES"
+    exit 1
   fi
 done
 

--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -29,9 +29,9 @@ docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood $1 $2 > /dev/null
 # is unavailable and we must probe the port manually.
 if uname|grep Darwin > /dev/null
 then
-    CONTAINER_IP=`docker-machine ip default`
+  CONTAINER_IP=`docker-machine ip default`
 else
-    CONTAINER_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
+  CONTAINER_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
 fi
 
 while ! nc -z $CONTAINER_IP 1224; do sleep 0.1; done

--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -15,21 +15,21 @@ function get_chrome () {
   DRIVERURL=https://chromedriver.storage.googleapis.com/$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip
   
   case $1 in
-      stable)
-          URL=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-          ;;
-      beta)
-          URL=https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-          ;;
-      canary)
-          URL=https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
-          ;;
-      *)
-          log "Unknown chrome version $1. Options are stable, beta, and canary."
-          exit 1
-          ;;
+    stable)
+      URL=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+      ;;
+    beta)
+      URL=https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+      ;;
+    canary)
+      URL=https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb
+      ;;
+    *)
+      log "Unknown chrome version $1. Options are stable, beta, and canary."
+      exit 1
+      ;;
   esac
-          cat <<EOF
+  cat <<EOF
 RUN echo BROWSER=chrome >/etc/test.conf
 ADD $DRIVERURL /tmp/driver.zip
 RUN unzip -qq /tmp/driver.zip -d /usr/bin
@@ -39,35 +39,35 @@ EOF
 }
 
 function get_localchrome () {
-    # validate the path.   
-    case $1 in
-        stable)
-            local v=$(chrome_build_path Release)
-            ;;
-        debug)
-            local v=$(chrome_build_path Debug)
-            ;;
-        *)
-            log "Unknown localchrome version $1. Options are stable and debug."
-            exit 1
-            ;;
-    esac
-    # localchrome is an additional mount at runtime, into
-    # /test/chrome.  Just generate a wrapper script here.
-        cat <<EOF
+  # validate the path.   
+  case $1 in
+    stable)
+      local v=$(chrome_build_path Release)
+      ;;
+    debug)
+      local v=$(chrome_build_path Debug)
+      ;;
+    *)
+      log "Unknown localchrome version $1. Options are stable and debug."
+      exit 1
+      ;;
+  esac
+  # localchrome is an additional mount at runtime, into
+  # /test/chrome.  Just generate a wrapper script here.
+  cat <<EOF
 RUN echo BROWSER=chrome >/etc/test.conf
 RUN echo '#!/bin/bash' >/usr/bin/google-chrome; echo 'pushd /test/chrome; ./chrome --no-sandbox \$@' >>/usr/bin/google-chrome ; chmod +x /usr/bin/google-chrome
 EOF
 }
 
 function get_firefox () {
-    cat <<EOF
+  cat <<EOF
 RUN echo BROWSER=firefox >/etc/test.conf
 RUN npm install jpm -g
 EOF
-    case $1 in
-        stable)
-            cat <<EOF
+  case $1 in
+    stable)
+      cat <<EOF
 RUN cd /tmp ; mkdir ff ; cd ff ; wget -O firefox-stable.tar.bz2 'https://download.mozilla.org/?product=firefox-latest&os=linux64'
 EOF
             ;;
@@ -75,34 +75,34 @@ EOF
             cat <<EOF
 RUN cd /tmp ; mkdir ff ; cd ff ; wget -O firefox-beta.tar.bz2 'https://download.mozilla.org/?product=firefox-beta-latest&os=linux64'
 EOF
-            ;;
-        canary)
-            cat <<EOF
+      ;;
+    canary)
+      cat <<EOF
 RUN cd /tmp ; mkdir ff ; cd ff ; wget -r -l1 -nd -A '*linux-x86_64.tar.bz2' https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/latest-mozilla-aurora/
 EOF
-            ;;
-        *)
-            log "Unknown firefox version $1. Options are stable, beta, and canary."
-            ;;
-    esac
-    cat <<EOF
-# Sometimes there are >1 versions in the folder, e.g. following a release.
-RUN cd /usr/share ; ls /tmp/ff/*.bz2|sort|tail -1|xargs tar xf
-RUN ln -s /usr/share/firefox/firefox /usr/bin/firefox
-EOF
+      ;;
+    *)
+      log "Unknown firefox version $1. Options are stable, beta, and canary."
+      ;;
+  esac
+  cat <<EOF
+  # Sometimes there are >1 versions in the folder, e.g. following a release.
+  RUN cd /usr/share ; ls /tmp/ff/*.bz2|sort|tail -1|xargs tar xf
+  RUN ln -s /usr/share/firefox/firefox /usr/bin/firefox
+  EOF
 
 }
 case $1 in
-    chrome)
-        get_chrome $2
-        ;;
-    firefox)
-        get_firefox $2
-        ;;
-    localchrome)
-        get_localchrome $2 $3
-        ;;
-    *)
-        log "Unknown browser $1.  Options are chrome, localchrome, and firefox."
-        exit 1
+  chrome)
+    get_chrome $2
+    ;;
+  firefox)
+    get_firefox $2
+    ;;
+  localchrome)
+    get_localchrome $2 $3
+    ;;
+  *)
+    log "Unknown browser $1.  Options are chrome, localchrome, and firefox."
+    exit 1
 esac

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -5,8 +5,8 @@
 
 if [ $# -lt 2 ]
 then
-    echo "Two arguments needed: browser and version."
-    exit 1
+  echo "Two arguments needed: browser and version."
+  exit 1
 fi
 source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
 

--- a/testing/run-scripts/run.sh
+++ b/testing/run-scripts/run.sh
@@ -6,21 +6,21 @@ RUNARGS="-i"
 while getopts n:t:d opt; do
   case $opt in
 	  n)
-          NUM=$OPTARG
-          ;;
-      t)
-          TASK=$OPTARG
-          ;;
-      d)
-          RUNARGS="-d"
-          ;;
-      *)
-          echo "$0 [-n NUM] [-t TASK] [-d]"
-          echo "  -n: Instance number NUM.  Port numbers are offset by this much."
-          echo "  -t: Task named TASK.  One of: bash, zork"
-          echo "  -d: Run docker image as daemon (pass -d to docker run)"
-          exit 1;
-          ;;
+      NUM=$OPTARG
+      ;;
+    t)
+      TASK=$OPTARG
+      ;;
+    d)
+      RUNARGS="-d"
+      ;;
+    *)
+      echo "$0 [-n NUM] [-t TASK] [-d]"
+      echo "  -n: Instance number NUM.  Port numbers are offset by this much."
+      echo "  -t: Task named TASK.  One of: bash, zork"
+      echo "  -d: Run docker image as daemon (pass -d to docker run)"
+      exit 1;
+      ;;
   esac
 done
 

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -21,41 +21,41 @@ BANNER=
 SSHD_PORT=5000
 
 function usage () {
-    echo "$0 [-p path] [-i invite code] [-u] [-w] [-d ip] [-b banner] browser-version"
-    echo "  -p: path to pre-built uproxy-lib repository"
-    echo "  -i: bootstrap invite (only for new installs, or with -w)"
-    echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
-    echo "  -w: when -u used, do not copy invites or metadata from current installation"
-    echo "  -d: override the detected public IP (for development only)"
-    echo "  -b: name to use in contacts list"
-    echo "  -h, -?: this help message"
-    echo
-    echo "Example browser-version: chrome-stable, firefox-canary"
-    exit 1
+  echo "$0 [-p path] [-i invite code] [-u] [-w] [-d ip] [-b banner] browser-version"
+  echo "  -p: path to pre-built uproxy-lib repository"
+  echo "  -i: bootstrap invite (only for new installs, or with -w)"
+  echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
+  echo "  -w: when -u used, do not copy invites or metadata from current installation"
+  echo "  -d: override the detected public IP (for development only)"
+  echo "  -b: name to use in contacts list"
+  echo "  -h, -?: this help message"
+  echo
+  echo "Example browser-version: chrome-stable, firefox-canary"
+  exit 1
 }
 
 while getopts p:i:uwd:b:h? opt; do
-    case $opt in
-        p) PREBUILT="$OPTARG" ;;
-        i) INVITE_CODE="$OPTARG" ;;
-        u) UPDATE=true ;;
-        w) WIPE=true ;;
-        d) PUBLIC_IP="$OPTARG" ;;
-        b) BANNER="$OPTARG" ;;
-        *) usage ;;
-    esac
+  case $opt in
+    p) PREBUILT="$OPTARG" ;;
+    i) INVITE_CODE="$OPTARG" ;;
+    u) UPDATE=true ;;
+    w) WIPE=true ;;
+    d) PUBLIC_IP="$OPTARG" ;;
+    b) BANNER="$OPTARG" ;;
+    *) usage ;;
+  esac
 done
 shift $((OPTIND-1))
 
 if [ $# -lt 1 ]
 then
-    usage
+  usage
 fi
 
 if [ "$WIPE" = true ] && [ "$UPDATE" = false ]
 then
-    echo "-u must be used when -w is used"
-    usage
+  echo "-u must be used when -w is used"
+  usage
 fi
 
 # Set the cloud instance's banner.
@@ -66,27 +66,27 @@ fi
 #  - server's hostname
 if [ -z "$BANNER" ]
 then
-    if docker ps -a | grep uproxy-sshd >/dev/null
+  if docker ps -a | grep uproxy-sshd >/dev/null
+  then
+    if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
     then
-        if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
-        then
-            docker start uproxy-sshd > /dev/null
-        fi
-        BANNER=`docker exec uproxy-sshd cat /banner`
-    else
-        # Quickly try (timeout after two seconds) DigitalOcean's
-        # metadata API which can tell us the region in which a
-        # droplet is located:
-        #   https://developers.digitalocean.com/documentation/metadata/#metadata-api-endpoints
-        BANNER=`curl -s -m 2 http://169.254.169.254/metadata/v1/region || echo -n ""`
-        if [ -n "$BANNER" ]
-        then
-            BANNER=`echo "$BANNER"|sed 's/ams./Amsterdam/;s/sgp./Singapore/;s/fra./Frankfurt/;s/tor./Toronto/;s/nyc./New York/;s/sfo./San Francisco/;s/lon./London/'`
-            BANNER="$BANNER (DigitalOcean)"
-        else
-            BANNER=`hostname`
-        fi
+      docker start uproxy-sshd > /dev/null
     fi
+    BANNER=`docker exec uproxy-sshd cat /banner`
+  else
+    # Quickly try (timeout after two seconds) DigitalOcean's
+    # metadata API which can tell us the region in which a
+    # droplet is located:
+    #   https://developers.digitalocean.com/documentation/metadata/#metadata-api-endpoints
+    BANNER=`curl -s -m 2 http://169.254.169.254/metadata/v1/region || echo -n ""`
+    if [ -n "$BANNER" ]
+    then
+      BANNER=`echo "$BANNER"|sed 's/ams./Amsterdam/;s/sgp./Singapore/;s/fra./Frankfurt/;s/tor./Toronto/;s/nyc./New York/;s/sfo./San Francisco/;s/lon./London/'`
+      BANNER="$BANNER (DigitalOcean)"
+    else
+      BANNER=`hostname`
+    fi
+  fi
 fi
 
 # Set the cloud instance's hostname.
@@ -96,53 +96,53 @@ fi
 #  - pull from DNS
 if [ -z "$PUBLIC_IP" ]
 then
-    if docker ps -a | grep uproxy-sshd >/dev/null
+  if docker ps -a | grep uproxy-sshd >/dev/null
+  then
+    if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
     then
-        if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
-        then
-            docker start uproxy-sshd > /dev/null
-        fi
-        # Don't fail if the current installation has no /hostname.
-        PUBLIC_IP=`docker exec uproxy-sshd cat /hostname || echo -n ""`
+      docker start uproxy-sshd > /dev/null
     fi
-    if [ -z "$PUBLIC_IP" ]
-    then
-        # Beautiful cross-platform one-liner cogged from:
-        #   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
-        PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
-    fi
+    # Don't fail if the current installation has no /hostname.
+    PUBLIC_IP=`docker exec uproxy-sshd cat /hostname || echo -n ""`
+  fi
+  if [ -z "$PUBLIC_IP" ]
+  then
+    # Beautiful cross-platform one-liner cogged from:
+    #   http://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-bash
+    PUBLIC_IP=`dig +short myip.opendns.com @resolver1.opendns.com`
+  fi
 fi
 
 # Migrate the giver and getter accounts' authorized_keys.
 if [ "$WIPE" = false ]
 then
-    if docker ps -a | grep uproxy-sshd >/dev/null
+  if docker ps -a | grep uproxy-sshd >/dev/null
+  then
+    if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
     then
-        if [ `docker inspect --format='{{ .State.Status }}' uproxy-sshd` != "running" ]
-        then
-            docker start uproxy-sshd > /dev/null
-        fi
-        GIVER_AUTH_KEYS=`docker exec uproxy-sshd cat /home/giver/.ssh/authorized_keys || echo -n ""`
-        GETTER_AUTH_KEYS=`docker exec uproxy-sshd cat /home/getter/.ssh/authorized_keys || echo -n ""`
-
-        # Because it's unclear what it would mean to migrate authorized_keys files
-        # when -i is supplied, restrict use of -i to new or wiping (-w) installs.
-        if [ -n "$INVITE_CODE" ]
-        then
-            echo "-i can only be used for new installs or with -w"
-            usage
-        fi
+      docker start uproxy-sshd > /dev/null
     fi
+    GIVER_AUTH_KEYS=`docker exec uproxy-sshd cat /home/giver/.ssh/authorized_keys || echo -n ""`
+    GETTER_AUTH_KEYS=`docker exec uproxy-sshd cat /home/getter/.ssh/authorized_keys || echo -n ""`
+
+    # Because it's unclear what it would mean to migrate authorized_keys files
+    # when -i is supplied, restrict use of -i to new or wiping (-w) installs.
+    if [ -n "$INVITE_CODE" ]
+    then
+      echo "-i can only be used for new installs or with -w"
+      usage
+    fi
+  fi
 fi
 
 if [ "$UPDATE" = true ]
 then
-    docker rm -f uproxy-sshd || true
-    docker rm -f uproxy-zork || true
-    docker rmi uproxy/sshd || true
-    # TODO: This will fail if there are any containers using the
-    #       image, e.g. run_pair.sh. Regular cloud users won't be.
-    docker rmi uproxy/$1 || true
+  docker rm -f uproxy-sshd || true
+  docker rm -f uproxy-zork || true
+  docker rmi uproxy/sshd || true
+  # TODO: This will fail if there are any containers using the
+  #       image, e.g. run_pair.sh. Regular cloud users won't be.
+  docker rmi uproxy/$1 || true
 fi
 
 # IP of the host machine.
@@ -151,69 +151,69 @@ HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
 
 # Start Zork, if necessary.
 if ! docker ps -a | grep uproxy-zork >/dev/null; then
-    if ! docker images | grep uproxy/$1 >/dev/null; then
-        BROWSER=$(echo $1 | cut -d - -f 1)
-        VERSION=$(echo $1 | cut -d - -f 2)
-        ${BASH_SOURCE%/*}/image_make.sh $BROWSER $VERSION
-    fi
-    HOSTARGS=
-    if [ ! -z "$PREBUILT" ]
-    then
-        NPM=false
-        HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
-    fi
-    RUNARGS=
-    if [ ! -z "$PREBUILT" ]
-    then
-        RUNARGS="$RUNARGS -p"
-    fi
-    if [ "$NPM" = true ]
-    then
-        RUNARGS="$RUNARGS -n"
-    fi
-    # NET_ADMIN is required to run iptables inside the container.
-    # Full list of capabilities:
-    #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
-    docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -z true
+  if ! docker images | grep uproxy/$1 >/dev/null; then
+    BROWSER=$(echo $1 | cut -d - -f 1)
+    VERSION=$(echo $1 | cut -d - -f 2)
+    ${BASH_SOURCE%/*}/image_make.sh $BROWSER $VERSION
+  fi
+  HOSTARGS=
+  if [ ! -z "$PREBUILT" ]
+  then
+    NPM=false
+    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+  fi
+  RUNARGS=
+  if [ ! -z "$PREBUILT" ]
+  then
+    RUNARGS="$RUNARGS -p"
+  fi
+  if [ "$NPM" = true ]
+  then
+    RUNARGS="$RUNARGS -n"
+  fi
+  # NET_ADMIN is required to run iptables inside the container.
+  # Full list of capabilities:
+  #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
+  docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh $RUNARGS -z true
 
-    echo -n "Waiting for Zork to come up..."
-    while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
-    echo "ready!"
+  echo -n "Waiting for Zork to come up..."
+  while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done
+  echo "ready!"
 fi
 
 # Start sshd, if necessary.
 if ! docker ps -a | grep uproxy-sshd >/dev/null; then
-    if ! docker images | grep uproxy/sshd >/dev/null; then
-        TMP_DIR=/tmp/uproxy-sshd
-        rm -fR $TMP_DIR
-        cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
+  if ! docker images | grep uproxy/sshd >/dev/null; then
+    TMP_DIR=/tmp/uproxy-sshd
+    rm -fR $TMP_DIR
+    cp -R ${BASH_SOURCE%/*}/../../sshd/ $TMP_DIR
 
-        echo -n "$BANNER" > $TMP_DIR/banner
-        echo -n "$PUBLIC_IP" > $TMP_DIR/hostname
+    echo -n "$BANNER" > $TMP_DIR/banner
+    echo -n "$PUBLIC_IP" > $TMP_DIR/hostname
 
-        docker build -t uproxy/sshd $TMP_DIR
-    fi
+    docker build -t uproxy/sshd $TMP_DIR
+  fi
 
-    # Add an /etc/hosts entry to the Zork container.
-    # Because the Zork container runs with --net=host, we can't use the
-    # regular, ever-so-slightly-more-elegant Docker notation.
-    docker run --restart=always -d -p $SSHD_PORT:22 --name uproxy-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
+  # Add an /etc/hosts entry to the Zork container.
+  # Because the Zork container runs with --net=host, we can't use the
+  # regular, ever-so-slightly-more-elegant Docker notation.
+  docker run --restart=always -d -p $SSHD_PORT:22 --name uproxy-sshd --add-host zork:$HOST_IP uproxy/sshd > /dev/null
 
-    # Configure access.
-    # In descending order of preference:
-    #  - migrate authorized_keys or apply -i
-    #  - issue a new invite
-    if [ -n "$GIVER_AUTH_KEYS" ] || [ -n "$GETTER_AUTH_KEYS" ]
+  # Configure access.
+  # In descending order of preference:
+  #  - migrate authorized_keys or apply -i
+  #  - issue a new invite
+  if [ -n "$GIVER_AUTH_KEYS" ] || [ -n "$GETTER_AUTH_KEYS" ]
+  then
+    docker exec uproxy-sshd sh -c "echo $GIVER_AUTH_KEYS > /home/giver/.ssh/authorized_keys"
+    docker exec uproxy-sshd sh -c "echo $GETTER_AUTH_KEYS > /home/getter/.ssh/authorized_keys"
+  else
+    if [ -n "$INVITE_CODE" ]
     then
-        docker exec uproxy-sshd sh -c "echo $GIVER_AUTH_KEYS > /home/giver/.ssh/authorized_keys"
-        docker exec uproxy-sshd sh -c "echo $GETTER_AUTH_KEYS > /home/getter/.ssh/authorized_keys"
+      INVITE_CODE=`docker exec uproxy-sshd /issue_invite.sh -i "$INVITE_CODE"`
     else
-        if [ -n "$INVITE_CODE" ]
-        then
-            INVITE_CODE=`docker exec uproxy-sshd /issue_invite.sh -i "$INVITE_CODE"`
-        else
-            INVITE_CODE=`docker exec uproxy-sshd /issue_invite.sh -c`
-            echo -e "\nINVITE CODE URL:\n$INVITE_CODE"
-        fi
+      INVITE_CODE=`docker exec uproxy-sshd /issue_invite.sh -c`
+      echo -e "\nINVITE CODE URL:\n$INVITE_CODE"
     fi
+  fi
 fi

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -21,57 +21,57 @@ PROXY_PORT=9999
 CONTAINER_PREFIX="uproxy"
 
 function usage () {
-    echo "$0 [-v] [-k] [-b branch] [-r repo] [-p path] [-m mtu] [-l latency] [-s port] [-u prefix] browserspec browserspec"
-    echo "  -b BRANCH: have containers check out this BRANCH.  Default is dev."
-    echo "  -r REPO: have containers clone this REPO.  "
-    echo "           Default is https://github.com/uProxy/uproxy-lib.git."
-    echo "  -p: path to pre-built uproxy-lib repository (overrides -b and -r)."
-    echo "  -v: enable VNC on containers.  They will be ports 5900 and 5901."
-    echo "  -k: KEEP containers after last process exits.  This is docker's --rm."
-    echo "  -m MTU: set the MTU on the getter's network interface."
-    echo "  -l latency: set latency (in ms) on the getter's network interface."
-    echo "  -s port: forwarding port for the proxy on the host.  Default is 9999."
-    echo "  -u prefix: prefix for getter and giver container names.  Default is uproxy."
-    echo "  -h, -?: this help message."
-    echo
-    echo "browserspec is a pair of browser-version."
-    echo "  Valid browsers are firefox and chrome, valid versions "
-    echo "  stable, beta, and canary, e.g. chrome-stable and firefox-beta."
-    exit 1
+  echo "$0 [-v] [-k] [-b branch] [-r repo] [-p path] [-m mtu] [-l latency] [-s port] [-u prefix] browserspec browserspec"
+  echo "  -b BRANCH: have containers check out this BRANCH.  Default is dev."
+  echo "  -r REPO: have containers clone this REPO.  "
+  echo "           Default is https://github.com/uProxy/uproxy-lib.git."
+  echo "  -p: path to pre-built uproxy-lib repository (overrides -b and -r)."
+  echo "  -v: enable VNC on containers.  They will be ports 5900 and 5901."
+  echo "  -k: KEEP containers after last process exits.  This is docker's --rm."
+  echo "  -m MTU: set the MTU on the getter's network interface."
+  echo "  -l latency: set latency (in ms) on the getter's network interface."
+  echo "  -s port: forwarding port for the proxy on the host.  Default is 9999."
+  echo "  -u prefix: prefix for getter and giver container names.  Default is uproxy."
+  echo "  -h, -?: this help message."
+  echo
+  echo "browserspec is a pair of browser-version."
+  echo "  Valid browsers are firefox and chrome, valid versions "
+  echo "  stable, beta, and canary, e.g. chrome-stable and firefox-beta."
+  exit 1
 }
 
 while getopts kvb:r:p:m:l:s:u:h? opt; do
-    case $opt in
-        k) KEEP=true ;;
-        v) VNC=true ;;
-        b) BRANCH="-b $OPTARG" ;;
-        r) REPO="-r $OPTARG" ;;
-        p) PREBUILT="$OPTARG" ;;
-        m) MTU="$OPTARG" ;;
-        l) LATENCY="$OPTARG" ;;
-        s) PROXY_PORT="$OPTARG" ;;
-        u) CONTAINER_PREFIX="$OPTARG" ;;
-        *) usage ;;
-    esac
+  case $opt in
+    k) KEEP=true ;;
+    v) VNC=true ;;
+    b) BRANCH="-b $OPTARG" ;;
+    r) REPO="-r $OPTARG" ;;
+    p) PREBUILT="$OPTARG" ;;
+    m) MTU="$OPTARG" ;;
+    l) LATENCY="$OPTARG" ;;
+    s) PROXY_PORT="$OPTARG" ;;
+    u) CONTAINER_PREFIX="$OPTARG" ;;
+    *) usage ;;
+  esac
 done
 shift $((OPTIND-1))
 
 if [ $# -lt 2 ]
 then
-    usage
+  usage
 fi
 
 if $VNC; then
-    VNCOPTS1="-p 5900:5900"
-    VNCOPTS2="-p 5901:5900"
-    RUNARGS="$RUNARGS -v"
+  VNCOPTS1="-p 5900:5900"
+  VNCOPTS2="-p 5901:5900"
+  RUNARGS="$RUNARGS -v"
 fi
 
 if [ "$PREBUILT" ]
 then
-    RUNARGS="$RUNARGS -p"
+  RUNARGS="$RUNARGS -p"
 else
-    RUNARGS="$RUNARGS $REPO $BRANCH"
+  RUNARGS="$RUNARGS $REPO $BRANCH"
 fi
 
 # Kill any running giver and getter containers.
@@ -83,46 +83,46 @@ for role in getter giver; do
 done
 
 function make_image () {
-    if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/$1 )" == "Xuproxy/$1" ]
-    then
-        echo "Reusing existing image uproxy/$1"
-    else
-        BROWSER=$(echo $1 | cut -d - -f 1)
-        VERSION=$(echo $1 | cut -d - -f 2)
-        ./image_make.sh $BROWSER $VERSION
-    fi
+  if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/$1 )" == "Xuproxy/$1" ]
+  then
+    echo "Reusing existing image uproxy/$1"
+  else
+    BROWSER=$(echo $1 | cut -d - -f 1)
+    VERSION=$(echo $1 | cut -d - -f 2)
+    ./image_make.sh $BROWSER $VERSION
+  fi
 }
 
 if ! make_image $1
 then
-    echo "FAILED: Could not make docker image for $1."
-    exit 1
+  echo "FAILED: Could not make docker image for $1."
+  exit 1
 fi
 
 if ! make_image $2
 then
-    echo "FAILED: Could not make docker image for $2."
-    exit 1
+  echo "FAILED: Could not make docker image for $2."
+  exit 1
 fi
 
 # $1 is the name of the resulting container.
 # $2 is the image to run, and the rest are flags.
 # TODO: Take a -b BRANCH arg and pass it to load-zork.sh
 function run_docker () {
-    local NAME=$1
-    local IMAGE=$2
-    shift; shift
-    IMAGENAME=uproxy/$IMAGE
-    local HOSTARGS=
-    if $KEEP
-    then
-        HOSTARGS="$HOSTARGS --rm=false"
-    fi
-    if [ ! -z "$PREBUILT" ]
-    then
-        HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
-    fi
-    docker run $HOSTARGS $@ --name $NAME $(docker_run_args $IMAGENAME) -d $IMAGENAME /test/bin/load-zork.sh $RUNARGS
+  local NAME=$1
+  local IMAGE=$2
+  shift; shift
+  IMAGENAME=uproxy/$IMAGE
+  local HOSTARGS=
+  if $KEEP
+  then
+    HOSTARGS="$HOSTARGS --rm=false"
+  fi
+  if [ ! -z "$PREBUILT" ]
+  then
+    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+  fi
+  docker run $HOSTARGS $@ --name $NAME $(docker_run_args $IMAGENAME) -d $IMAGENAME /test/bin/load-zork.sh $RUNARGS
 }
 
 run_docker $CONTAINER_PREFIX-getter $1 $VNCOPTS1 -p :9000 -p $PROXY_PORT:9999
@@ -131,7 +131,7 @@ run_docker $CONTAINER_PREFIX-giver $2 $VNCOPTS2 -p :9000
 CONTAINER_IP=localhost
 if uname|grep Darwin > /dev/null
 then
-    CONTAINER_IP=`docker-machine ip default`
+  CONTAINER_IP=`docker-machine ip default`
 fi
 
 GETTER_COMMAND_PORT=`docker port $CONTAINER_PREFIX-getter 9000|cut -d':' -f2`
@@ -143,12 +143,12 @@ echo
 
 if [ -n "$MTU" ]
 then
-    ./set-mtu.sh $CONTAINER_PREFIX-getter $MTU
+  ./set-mtu.sh $CONTAINER_PREFIX-getter $MTU
 fi
 
 if [ -n "$LATENCY" ]
 then
-    ./set-latency.sh $CONTAINER_PREFIX-getter qdisc add dev eth0 root netem delay "$LATENCY"ms
+  ./set-latency.sh $CONTAINER_PREFIX-getter qdisc add dev eth0 root netem delay "$LATENCY"ms
 fi
 
 echo -n "Waiting for giver to come up"

--- a/testing/run-scripts/set-ns.sh
+++ b/testing/run-scripts/set-ns.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 cleanup=0
 case "$1" in
--c)
-	cleanup=1
-	shift
-	;;
+  -c)
+	  cleanup=1
+	  shift
+	  ;;
 esac
 
 dockerid=${1:?'Docker ID hash must be provided as sole argument'}
@@ -25,30 +25,30 @@ daddr=$(echo "$addrmask" | sed 's,[0-9]*/[0-9]*,99,')
 naddr=$(echo "$addrmask" | sed 's,[0-9]*/[0-9]*,0,')
 
 case "$cleanup" in
-0)
+  0)
     echo "Making /var/run/netns/$pid"
-	sudo mkdir -p /var/run/netns
-	sudo ln -s /proc/$pid/ns/net /var/run/netns/$pid
+	  sudo mkdir -p /var/run/netns
+	  sudo ln -s /proc/$pid/ns/net /var/run/netns/$pid
 
     echo "Making veth devices"
-	sudo ip link add A type veth peer name B
-	sudo brctl addif docker0 A
-	sudo ip link set A up
+	  sudo ip link add A type veth peer name B
+	  sudo brctl addif docker0 A
+	  sudo ip link set A up
 
-	ethaddr=$(dd if=/dev/urandom count=6 bs=1 status=none | od -t x1 | cut -d ' ' -f 2- | head -1 | tr ' ' :)
+	  ethaddr=$(dd if=/dev/urandom count=6 bs=1 status=none | od -t x1 | cut -d ' ' -f 2- | head -1 | tr ' ' :)
     echo "Setting ethernet address $ethaddr"
-	sudo ip link set B netns $pid
-	sudo ip netns exec $pid ip link set dev B name eth0
-	sudo ip netns exec $pid ip link set eth0 address 01:23:45:67:89:ab
-	sudo ip netns exec $pid ip link set eth0 up
-	sudo ip netns exec $pid ip addr add $daddr/$mask dev eth0
-	sudo ip netns exec $pid ip route add default via $addr
+	  sudo ip link set B netns $pid
+	  sudo ip netns exec $pid ip link set dev B name eth0
+	  sudo ip netns exec $pid ip link set eth0 address 01:23:45:67:89:ab
+	  sudo ip netns exec $pid ip link set eth0 up
+	  sudo ip netns exec $pid ip addr add $daddr/$mask dev eth0
+	  sudo ip netns exec $pid ip route add default via $addr
 
     echo "Setting up NAT."
-	sudo iptables -t nat -A POSTROUTING -s $naddr/$mask -j MASQUERADE
-	;;
-1)
-	sudo rm /var/run/netns/$pid
-	sudo iptables -t nat -D POSTROUTING -s $naddr/$mask -j MASQUERADE
-	;;
+	  sudo iptables -t nat -A POSTROUTING -s $naddr/$mask -j MASQUERADE
+	  ;;
+  1)
+	  sudo rm /var/run/netns/$pid
+	  sudo iptables -t nat -D POSTROUTING -s $naddr/$mask -j MASQUERADE
+	  ;;
 esac

--- a/testing/run-scripts/utils.sh
+++ b/testing/run-scripts/utils.sh
@@ -8,20 +8,20 @@
 
 # Prints its arguments to stdout.
 function log () {
-    echo $@ >&2
+  echo $@ >&2
 }
 
 # Sets CHROMEDIRPATH to the path of the locally-built chrome binaries.
 # $1 is the name of the version.  Debug or Release.  Contains logic to
 # find the full chrome build path.  Exits with error if not found.
 function chrome_build_path () {
-    local CHROMEDIRPATH=${CHROME_BUILD_DIR:-`pwd`}/out/$1
-    if [ ! -d $CHROMEDIRPATH ]
-    then
-        log "$CHROMEDIRPATH does not exist.  Aborting. Try setting CHROME_BUILD_DIR to your src directory."
-        exit 1
-    fi
-    echo $CHROMEDIRPATH
+  local CHROMEDIRPATH=${CHROME_BUILD_DIR:-`pwd`}/out/$1
+  if [ ! -d $CHROMEDIRPATH ]
+  then
+    log "$CHROMEDIRPATH does not exist.  Aborting. Try setting CHROME_BUILD_DIR to your src directory."
+    exit 1
+  fi
+  echo $CHROMEDIRPATH
 }
 
 
@@ -32,40 +32,40 @@ function chrome_build_path () {
 # of the chrome build directory.  Assumes the image name is in
 # uproxy/browser-version format.
 function docker_run_args () {
-    local FULL_IMAGE_NAME=$1
-    shift
-    local IMAGE=$(echo $FULL_IMAGE_NAME | cut -d / -f 2)
-    local BROWSER=$(echo $IMAGE | cut -d - -f 1)
-    local VERSION=$(echo $IMAGE | cut -d - -f 2)
-    local RUNARGS=
-    if [ "x$BROWSER" == "xlocalchrome" ]
+  local FULL_IMAGE_NAME=$1
+  shift
+  local IMAGE=$(echo $FULL_IMAGE_NAME | cut -d / -f 2)
+  local BROWSER=$(echo $IMAGE | cut -d - -f 1)
+  local VERSION=$(echo $IMAGE | cut -d - -f 2)
+  local RUNARGS=
+  if [ "x$BROWSER" == "xlocalchrome" ]
+  then
+    local CPATH=
+    if [ "x$VERSION" == "xrelease" ]
     then
-        local CPATH=
-        if [ "x$VERSION" == "xrelease" ]
-        then
-            CPATH=$(chrome_build_path Release)
-        else
-            CPATH=$(chrome_build_path Debug)
-        fi
-        RUNARGS="$RUNARGS -v ${CPATH}:/test/chrome"
+      CPATH=$(chrome_build_path Release)
+    else
+      CPATH=$(chrome_build_path Debug)
     fi
-    echo $RUNARGS
+    RUNARGS="$RUNARGS -v ${CPATH}:/test/chrome"
+  fi
+  echo $RUNARGS
 }
 
 function prepare_docker_pid () {
-    pid=$(docker inspect -f '{{.State.Pid}}' $1)
-    if [ ! -L /var/run/netns/$pid ]
-    then
-        echo "[Making network namespace for $pid accessible]"
-        sudo mkdir -p /var/run/netns
-        sudo ln -s /proc/$pid/ns/net /var/run/netns/$pid
-        echo "[Created /var/run/netns $pid]"
-    fi
+  pid=$(docker inspect -f '{{.State.Pid}}' $1)
+  if [ ! -L /var/run/netns/$pid ]
+  then
+    echo "[Making network namespace for $pid accessible]"
+    sudo mkdir -p /var/run/netns
+    sudo ln -s /proc/$pid/ns/net /var/run/netns/$pid
+    echo "[Created /var/run/netns $pid]"
+  fi
 }
 
 
 # Given a docker container ID in $1, returns a PID for it.
 function docker_pid () {
-    docker inspect -f '{{.State.Pid}}' $1
+  docker inspect -f '{{.State.Pid}}' $1
 }
 


### PR DESCRIPTION
To prevent these issues from coming up in future pull requests - this switches all shell scripts to use 4 space indenting, which I think is fairly standard. I'm happy to switch to two if that's preferred - I actually prefer it for Python and Javascript, but I do think 4 is pretty good for bash so I'm happy either way. In any case, I want my editor to stop complaining and reindenting every other file completely when I open it.
