### PR TITLE
add unattended-upgrades to cloud image

### DIFF
--- a/sshd/Dockerfile
+++ b/sshd/Dockerfile
@@ -1,7 +1,7 @@
 FROM library/ubuntu:trusty
 
 RUN apt-get update -qq
-RUN apt-get install -y openssh-server supervisor dnsutils jq
+RUN apt-get install -y openssh-server supervisor dnsutils jq unattended-upgrades
 
 RUN addgroup giver
 RUN adduser --disabled-password --gecos 'uProxy Giver' --ingroup giver giver

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -55,7 +55,7 @@ cat <<EOF > $TMP_DIR/Dockerfile
 FROM library/ubuntu:trusty
 
 RUN apt-get -qq update
-RUN apt-get -qq install wget unzip xvfb fvwm supervisor iptables x11vnc
+RUN apt-get -qq install wget unzip xvfb fvwm supervisor iptables x11vnc unattended-upgrades
 
 RUN mkdir /test
 COPY test /test


### PR DESCRIPTION
Re: https://github.com/uProxy/uproxy/issues/2038 and our recently chat - looks like unattended-upgrades is _not_ currently present in the generated cloud images. I believe that adding it is simple though, and I also think the default configuration is what we want (that is, enable automatic security updates and disable others).
