### PR TITLE
add uproxy-zork docker hub image

### DIFF
--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -59,9 +59,6 @@ if [ "$DOCKER" = true ]
 then
   cat <<EOF > $TMP_DIR/Dockerfile
 FROM soycode/uproxy-zork
-
-RUN apt-get -qq update
-RUN apt-get -qq upgrade
 EOF
 
 else

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -5,31 +5,35 @@ set -e
 GIT=false
 BRANCH=
 PREBUILT=false
+DOCKER=false
 
 function usage () {
-  echo "$0 [-g] [-b branch] [-p] [-h] browser version"
+  echo "$0 [-g] [-b branch] [-p] [-d] [-h] browser version"
   echo "  -g: pull code from git (conflicts with -p)"
   echo "  -b: git branch to pull (default: HEAD's referant)"
-  echo "  -p: use a pre-built uproxy-lib (conflicts with -g)"
+  echo "  -p: use a pre-built uproxy-lib (conflicts with -g, -d)"
+  echo "  -d: use a pre-built image from Docker Hub (conflicts with -b, -p)"
   echo "  -h, -?: this help message"
   echo
   echo "Without -g or -p the latest uproxy-lib NPM will be run."
   exit 1;
 }
 
-while getopts gb:ph? opt; do
+while getopts gb:pdh? opt; do
   case $opt in
     g) GIT=true ;;
     b) BRANCH="-b $OPTARG" ;;
     p) PREBUILT=true ;;
+    d) DOCKER=true ;;
     *) usage ;;
   esac
 done
 shift $((OPTIND-1))
 
-if [ "$GIT" = true ] && [ "$PREBUILT" = true ]
+if [ [ "$GIT" = true ] && [ [ "$PREBUILT" = true ] || [ "$DOCKER"" = true ] ] ||
+     [ [ "$PREBUILT" = true ] && [ "$DOCKER" = true ] ] ]
 then
-  echo "cannot use both -g and -p"
+  echo "cannot use -g, -p, or -d with each other"
   usage
 fi
 
@@ -51,7 +55,17 @@ TMP_DIR=`mktemp -d`
 
 cp -R ${BASH_SOURCE%/*}/../integration/test $TMP_DIR/test
 
-cat <<EOF > $TMP_DIR/Dockerfile
+if [ "$DOCKER" = true ]
+then
+  cat <<EOF > $TMP_DIR/Dockerfile
+FROM soycode/uproxy-zork
+
+RUN apt-get -qq update
+RUN apt-get -qq upgrade
+EOF
+
+else
+  cat <<EOF > $TMP_DIR/Dockerfile
 FROM library/ubuntu:trusty
 
 RUN apt-get -qq update
@@ -65,25 +79,26 @@ EXPOSE 9999
 EXPOSE 5900
 EOF
 
-# load-zork.sh needs a copy of Zork in:
-#   /test/src/uproxy-lib/build/dist/samples/zork-{chrome|firefox}app.
-# Unless -p was specified, we need to pull it down.
-if [ "$GIT" = true ]
-then
-  cat <<EOF >> $TMP_DIR/Dockerfile
+  # load-zork.sh needs a copy of Zork in:
+  #   /test/src/uproxy-lib/build/dist/samples/zork-{chrome|firefox}app.
+  # Unless -p was specified, we need to pull it down.
+  if [ "$GIT" = true ]
+  then
+    cat <<EOF >> $TMP_DIR/Dockerfile
 RUN apt-get -qq install git nodejs npm
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN npm install -g grunt-cli
 RUN mkdir -p /test/src && cd /test/src && git clone https://github.com/uProxy/uproxy-lib.git $BRANCH
 RUN cd /test/src/uproxy-lib && ./setup.sh install && grunt zork
 EOF
-elif [ "$PREBUILT" = false ]
-then
-  cat <<EOF >> $TMP_DIR/Dockerfile
+  elif [ "$PREBUILT" = false ]
+  then
+    cat <<EOF >> $TMP_DIR/Dockerfile
 RUN apt-get -qq install npm
 RUN npm install --prefix /test/src uproxy-lib
 RUN ln -s /test/src/node_modules/uproxy-lib /test/src/uproxy-lib
 EOF
+  fi
 fi
 
 ./gen_browser.sh "$@" >> $TMP_DIR/Dockerfile

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -4,25 +4,26 @@ set -e
 
 GIT=false
 BRANCH=
+IMAGE=
 PREBUILT=false
-DOCKER=false
 
 function usage () {
-  echo "$0 [-g] [-b branch] [-p] [-d] [-h] browser version"
-  echo "  -g: pull code from git (conflicts with -p)"
-  echo "  -b: git branch to pull (default: HEAD's referant)"
-  echo "  -p: use a pre-built uproxy-lib (conflicts with -g, -d)"
-  echo "  -d: use a pre-built image from Docker Hub (conflicts with -b, -p)"
+  echo "$0 [-g] [-b branch] [-m image] [-p] [-h] browser version"
+  echo "  -g: pull code from git (conflicts with -m, -p)"
+  echo "  -b: git branch to pull (expects -g, default: HEAD's referant)"
+  echo "  -m: use a specified Docker Hub image (conflicts with -g, -p)"
+  echo "  -p: use a pre-built uproxy-lib (conflicts with -g, -m)"
   echo "  -h, -?: this help message"
   echo
   echo "Without -g or -p the latest uproxy-lib NPM will be run."
   exit 1;
 }
 
-while getopts gb:pdh? opt; do
+while getopts gb:m:ph? opt; do
   case $opt in
     g) GIT=true ;;
     b) BRANCH="-b $OPTARG" ;;
+    m) IMAGE="$OPTARG" ;;
     p) PREBUILT=true ;;
     d) DOCKER=true ;;
     *) usage ;;
@@ -30,10 +31,10 @@ while getopts gb:pdh? opt; do
 done
 shift $((OPTIND-1))
 
-if [ [ "$GIT" = true ] && [ [ "$PREBUILT" = true ] || [ "$DOCKER"" = true ] ] ||
-     [ [ "$PREBUILT" = true ] && [ "$DOCKER" = true ] ] ]
+if [ [ "$GIT" = true ] && [ [ "$PREBUILT" = true ] || [ -n "$IMAGE"  ] ] ||
+       [ [ "$PREBUILT" = true ] && [ -n "IMAGE" ] ] ]
 then
-  echo "cannot use -g, -p, or -d with each other"
+  echo "cannot use -g, -p, or -m with each other"
   usage
 fi
 
@@ -55,10 +56,10 @@ TMP_DIR=`mktemp -d`
 
 cp -R ${BASH_SOURCE%/*}/../integration/test $TMP_DIR/test
 
-if [ "$DOCKER" = true ]
+if [ -n "$IMAGE" ]
 then
   cat <<EOF > $TMP_DIR/Dockerfile
-FROM soycode/uproxy-zork
+FROM $IMAGE
 EOF
 
 else

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-IMAGE=
+IMAGE="soycode/uproxy-zork"
 INVITE_CODE=
 UPDATE=false
 WIPE=false
@@ -21,7 +21,7 @@ AUTOMATED=false
 SSHD_PORT=5000
 
 function usage () {
-  echo "$0 [-m image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a]"
+  echo "$0 [-m image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a] browser-version"
   echo "  -m: use a specified Docker Hub image (defaults to soycode/uproxy-zork)"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
   echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
@@ -153,11 +153,7 @@ HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
 
 # Start Zork, if necessary.
 if ! docker ps -a | grep uproxy-zork >/dev/null; then
-  if ! docker images | grep uproxy/$1 >/dev/null; then
-    if [ -n "$IMAGE" ]
-    then
-      IMAGE="soycode/uproxy-zork"
-    fi
+  if ! docker images | grep $IMAGE >/dev/null; then
     ZORK_DIR=`mktemp -d`
     cp -R ${BASH_SOURCE%/*}/../integration/test $ZORK_DIR/test
     echo "FROM $IMAGE" > $ZORK_DIR/Dockerfile

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-IMAGE=
+IMAGE="soycode/uproxy-zork"
 INVITE_CODE=
 UPDATE=false
 WIPE=false
@@ -153,11 +153,7 @@ HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
 
 # Start Zork, if necessary.
 if ! docker ps -a | grep uproxy-zork >/dev/null; then
-  if ! docker images | grep uproxy/$1 >/dev/null; then
-    if [ -n "$IMAGE" ]
-    then
-      IMAGE="soycode/uproxy-zork"
-    fi
+  if ! docker images | grep $IMAGE >/dev/null; then
     ZORK_DIR=`mktemp -d`
     cp -R ${BASH_SOURCE%/*}/../integration/test $ZORK_DIR/test
     echo "FROM $IMAGE" > $ZORK_DIR/Dockerfile

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -21,7 +21,7 @@ AUTOMATED=false
 SSHD_PORT=5000
 
 function usage () {
-  echo "$0 [-m image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a] browser-version"
+  echo "$0 [-m image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a]"
   echo "  -m: use a specified Docker Hub image (defaults to soycode/uproxy-zork)"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
   echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
@@ -144,7 +144,7 @@ then
   docker rmi uproxy/sshd || true
   # TODO: This will fail if there are any containers using the
   #       image, e.g. run_pair.sh. Regular cloud users won't be.
-  docker rmi uproxy/$1 || true
+  docker rmi $IMAGE || true
 fi
 
 # IP of the host machine.
@@ -162,7 +162,7 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   # NET_ADMIN is required to run iptables inside the container.
   # Full list of capabilities:
   #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
-  docker run --restart=always --net=host --cap-add NET_ADMIN --name uproxy-zork -d uproxy/$1 /test/bin/load-zork.sh -z
+  docker run --restart=always --net=host --cap-add NET_ADMIN --name uproxy-zork -d $IMAGE /test/bin/load-zork.sh -z
 
   echo -n "Waiting for Zork to come up..."
   while ! ((echo ping ; sleep 0.5) | nc -w 1 $HOST_IP 9000 | grep ping) > /dev/null; do echo -n .; done

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -151,12 +151,6 @@ HOST_IP=`ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1`
 
 # Start Zork, if necessary.
 if ! docker ps -a | grep uproxy-zork >/dev/null; then
-  if ! docker images | grep $IMAGE >/dev/null; then
-    ZORK_DIR=`mktemp -d`
-    cp -R ${BASH_SOURCE%/*}/../integration/test $ZORK_DIR/test
-    echo "FROM $IMAGE" > $ZORK_DIR/Dockerfile
-    docker build -t $IMAGE $ZORK_DIR
-  fi
   HOSTARGS=
   if [ -n "$PREBUILT" ]
   then

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -22,7 +22,7 @@ SSHD_PORT=5000
 
 function usage () {
   echo "$0 [-p path] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a] browser-version"
-  echo "  -p: use a pre-built uproxy-lib"
+  echo "  -p: use a pre-built uproxy-zork docker image"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
   echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
   echo "  -w: when -u used, do not copy invites or metadata from current installation"
@@ -159,7 +159,7 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
     IMAGEARGS=
     if [ -n "$PREBUILT" ]
     then
-      IMAGEARGS="-p"
+      IMAGEARGS="-d"
     fi
     ${BASH_SOURCE%/*}/image_make.sh $IMAGEARGS $BROWSER $VERSION
   fi

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -11,7 +11,7 @@
 set -e
 
 PREBUILT=
-IMAGE="soycode/uproxy-zork"
+IMAGE="uproxy/zork"
 INVITE_CODE=
 UPDATE=false
 WIPE=false
@@ -24,7 +24,7 @@ SSHD_PORT=5000
 function usage () {
   echo "$0 [-p path] [-m image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a]"
   echo "  -p: use a pre-built uproxy-lib"
-  echo "  -m: use a specified Docker Hub image (defaults to soycode/uproxy-zork)"
+  echo "  -m: use a specified Docker Hub image (defaults to uproxy/zork)"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
   echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
   echo "  -w: when -u used, do not copy invites or metadata from current installation"


### PR DESCRIPTION
Related to https://github.com/uProxy/uproxy/issues/2063

Doesn't fully resolve the issue as we also need uproxy-sshd, but will put that in a separate pull request for clarity.

For this, I have published the image (https://hub.docker.com/r/soycode/uproxy-zork/) and tested pulling on Linode (running this version of run_cloud.sh, which defaults to pulling uproxy-zork from Docker Hub), and it worked. It wasn't a dramatic speedup, but that's probably because it was the first time Linode pulled the soycode/uproxy-zork image (whereas the ubuntu/trusty image is definitely cached). Subsequent runs should be faster (and similarly, first run on DO will be slow, but subsequent should get faster).
