### PR TITLE
remove dependency on image_make.sh from run_pair.sh

### DIFF
--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -40,6 +40,7 @@ function usage () {
   exit 1
 }
 
+# TODO: replace browser-version with a Docker image name, ala run_cloud.sh
 while getopts gb:p:kvr:m:l:s:u:h? opt; do
   case $opt in
     g) GIT=true ;;
@@ -86,37 +87,6 @@ for role in getter giver; do
     docker rm -f $CONTAINER_PREFIX-$role > /dev/null
   fi
 done
-
-function make_image () {
-  if [ "X$(docker images | tail -n +2 | awk '{print $1}' | grep uproxy/$1 )" == "Xuproxy/$1" ]
-  then
-    echo "Reusing existing image uproxy/$1"
-  else
-    BROWSER=$(echo $1 | cut -d - -f 1)
-    VERSION=$(echo $1 | cut -d - -f 2)
-    IMAGEARGS=
-    if [ -n "$PREBUILT" ]
-    then
-      IMAGEARGS="-p"
-    elif [ "$GIT" = true ]
-    then
-      IMAGEARGS="-g -b $BRANCH"
-    fi
-    ./image_make.sh $IMAGEARGS $BROWSER $VERSION
-  fi
-}
-
-if ! make_image $1
-then
-  echo "FAILED: Could not make docker image for $1."
-  exit 1
-fi
-
-if ! make_image $2
-then
-  echo "FAILED: Could not make docker image for $2."
-  exit 1
-fi
 
 # $1 is the name of the resulting container.
 # $2 is the image to run, and the rest are flags.


### PR DESCRIPTION
I uploaded all of the the `uproxy/chrome-stable`, `uproxy/chrome-beta`, etc., images to Docker Hub. I think this will make things much easier and faster for others on the team who need to run ad-hoc Docker-based tests.

So, just like we did for `run_cloud.sh`, I've removed the call from `run_pair.sh` to `image_make.sh` (yes, we should change the args here to specify a Docker image instead like we did for `run_cloud.sh`...but I wanna at least get this done in time for someone else to run through the uproxy-lib release process next week).