### PR TITLE
remove osx-specific hacks now docker hub is in beta

### DIFF
--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -27,12 +27,7 @@ docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood $1 $2 > /dev/null
 
 # Wait until the service is actually up; because we use -d, docker wait
 # is unavailable and we must probe the port manually.
-if uname|grep Darwin > /dev/null
-then
-  CONTAINER_IP=`docker-machine ip default`
-else
-  CONTAINER_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
-fi
+CONTAINER_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
 
 while ! nc -z $CONTAINER_IP 1224; do sleep 0.1; done
 

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -111,17 +111,11 @@ function run_docker () {
 run_docker $CONTAINER_PREFIX-getter $1 $VNCOPTS1 -p :9000 -p $PROXY_PORT:9999
 run_docker $CONTAINER_PREFIX-giver $2 $VNCOPTS2 -p :9000
 
-CONTAINER_IP=localhost
-if uname|grep Darwin > /dev/null
-then
-  CONTAINER_IP=`docker-machine ip default`
-fi
-
 GETTER_COMMAND_PORT=`docker port $CONTAINER_PREFIX-getter 9000|cut -d':' -f2`
 GIVER_COMMAND_PORT=`docker port $CONTAINER_PREFIX-giver 9000|cut -d':' -f2`
 
 echo -n "Waiting for getter to come up"
-while ! ((echo ping ; sleep 0.5) | nc -w 1 $CONTAINER_IP $GETTER_COMMAND_PORT | grep ping) > /dev/null; do echo -n .; done
+while ! ((echo ping ; sleep 0.5) | nc -w 1 localhost $GETTER_COMMAND_PORT | grep ping) > /dev/null; do echo -n .; done
 echo
 
 if [ -n "$MTU" ]
@@ -135,12 +129,12 @@ then
 fi
 
 echo -n "Waiting for giver to come up"
-while ! ((echo ping ; sleep 0.5) | nc -w 1 $CONTAINER_IP $GIVER_COMMAND_PORT | grep ping) > /dev/null; do echo -n .; done
+while ! ((echo ping ; sleep 0.5) | nc -w 1 localhost $GIVER_COMMAND_PORT | grep ping) > /dev/null; do echo -n .; done
 echo
 
 echo "Connecting pair..."
 sleep 2 # make sure nc is shutdown
-./connect-pair.py $CONTAINER_IP $GETTER_COMMAND_PORT $CONTAINER_IP $GIVER_COMMAND_PORT
+./connect-pair.py localhost $GETTER_COMMAND_PORT localhost $GIVER_COMMAND_PORT
 
 echo "SOCKS proxy should be available, sample command:"
-echo "  curl -x socks5h://$CONTAINER_IP:$PROXY_PORT www.example.com"
+echo "  curl -x socks5h://localhost:$PROXY_PORT www.example.com"


### PR DESCRIPTION
Docker Hub! Much better for OSX. This removes the OSX-specific hacks. `release.py` still won't run because the flood server stuff could really use some love but now `run_pair.sh` **does** work just fine on OSX :-)
