### PR TITLE
update paths and args for pre-built mode, following uproxy-lib merge

### DIFF
--- a/testing/integration/test/etc/supervisord-chrome.conf
+++ b/testing/integration/test/etc/supervisord-chrome.conf
@@ -1,7 +1,7 @@
 [supervisord]
 
 [program:chrome]
-command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy-lib/build/dist/samples/zork-chromeapp --no-default-browser-check --no-first-run
+command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy/build/dev/uproxy/lib/samples/zork-chromeapp --no-default-browser-check --no-first-run
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/zork.log

--- a/testing/integration/test/etc/supervisord-firefox.conf
+++ b/testing/integration/test/etc/supervisord-firefox.conf
@@ -1,7 +1,7 @@
 [supervisord]
 
 [program:firefox]
-directory=/test/src/uproxy-lib/build/dist/samples/zork-firefoxapp
+directory=/test/src/uproxy/build/dev/uproxy/lib/samples/zork-firefoxapp
 command=jpm run -b /usr/bin/firefox
 autorestart=true
 redirect_stderr=true

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -10,7 +10,7 @@ function usage () {
   echo "$0 [-g] [-b branch] [-p] [-h] browser version"
   echo "  -g: pull code from git (conflicts with -p)"
   echo "  -b: git branch to pull (default: HEAD's referant)"
-  echo "  -p: use a pre-built uproxy-lib (conflicts with -g)"
+  echo "  -p: use a pre-built uproxy (conflicts with -g)"
   echo "  -h, -?: this help message"
   echo
   echo "Without -g or -p the latest uproxy-lib NPM will be run."
@@ -66,7 +66,7 @@ EXPOSE 5900
 EOF
 
 # load-zork.sh needs a copy of Zork in:
-#   /test/src/uproxy-lib/build/dist/samples/zork-{chrome|firefox}app.
+#   /test/src/uproxy/build/dev/uproxy/lib/samples/zork-{chrome|firefox}app.
 # Unless -p was specified, we need to pull it down.
 if [ "$GIT" = true ]
 then

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-# This is a major part of the uproxy-lib release process:
-#   https://github.com/uProxy/uproxy-lib
+# Part of the uProxy release process:
+#   https://github.com/uProxy/uproxy
 # Currently, this performs two important tests on every
 # getter/giver combination of the stable, beta, and canary
 # releases of Chrome and Firefox:
@@ -17,7 +17,7 @@ import itertools
 import subprocess
 
 parser = argparse.ArgumentParser(
-    description='Cross-browser tests for uproxy-lib release process.')
+    description='Cross-browser tests for uproxy release process.')
 parser.add_argument('clone_path', help='path to pre-built uproxy-lib repo')
 parser.add_argument('--browsers', help='browsers to test', nargs='+', default=['chrome', 'firefox'])
 parser.add_argument('--versions', help='browser versions to test', nargs='+', default=['stable', 'beta', 'canary'])

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -24,7 +24,7 @@ SSHD_PORT=5000
 
 function usage () {
   echo "$0 [-p path] [-z zork_image] [-s sshd_image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a]"
-  echo "  -p: use a pre-built uproxy-lib"
+  echo "  -p: use a pre-built uproxy"
   echo "  -z: use a specified Zork image (defaults to uproxy/zork)"
   echo "  -s: use a specified sshd image (defaults to uproxy/sshd)"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
@@ -134,7 +134,7 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   HOSTARGS=
   if [ -n "$PREBUILT" ]
   then
-    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy"
   fi
   # NET_ADMIN is required to run iptables inside the container.
   # Full list of capabilities:

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -25,7 +25,7 @@ function usage () {
   echo "$0 [-g] [-b branch] [-p path] [-v] [-k] [-m mtu] [-l latency] [-s port] [-u prefix] browserspec browserspec"
   echo "  -g: pull code from git (conflicts with -p)"
   echo "  -b: git branch to pull (default: HEAD's referant)"
-  echo "  -p: use a pre-built uproxy-lib (conflicts with -g)"
+  echo "  -p: use a pre-built uproxy (conflicts with -g)"
   echo "  -v: enable VNC on containers.  They will be ports 5900 and 5901."
   echo "  -k: KEEP containers after last process exits.  This is docker's --rm."
   echo "  -m MTU: set the MTU on the getter's network interface."
@@ -103,7 +103,7 @@ function run_docker () {
   fi
   if [ ! -z "$PREBUILT" ]
   then
-    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy-lib"
+    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy"
   fi
   docker run $HOSTARGS $@ --name $NAME $(docker_run_args $IMAGENAME) -d $IMAGENAME /sbin/my_init -- /test/bin/load-zork.sh $RUNARGS
 }


### PR DESCRIPTION
Deploying cloud servers is a little bit of a mess right now - this makes the "use a prebuilt local repo" work again. Working on getting NPM/prebuilt support working again :-)