### PR TITLE
move away from NPM for cloud images

### DIFF
--- a/testing/integration/test/etc/supervisord-chrome.conf
+++ b/testing/integration/test/etc/supervisord-chrome.conf
@@ -1,7 +1,7 @@
 [supervisord]
 
 [program:chrome]
-command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/src/uproxy/build/dev/uproxy/lib/samples/zork-chromeapp --no-default-browser-check --no-first-run
+command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/zork/zork-chromeapp --no-default-browser-check --no-first-run
 autorestart=true
 redirect_stderr=true
 stdout_logfile=/var/log/zork.log

--- a/testing/integration/test/etc/supervisord-firefox.conf
+++ b/testing/integration/test/etc/supervisord-firefox.conf
@@ -1,7 +1,7 @@
 [supervisord]
 
 [program:firefox]
-directory=/test/src/uproxy/build/dev/uproxy/lib/samples/zork-firefoxapp
+directory=/test/zork/zork-firefoxapp
 command=jpm run -b /usr/bin/firefox
 autorestart=true
 redirect_stderr=true

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -2,42 +2,24 @@
 
 set -e
 
-GIT=false
-BRANCH=
-PREBUILT=false
+PREBUILT=
 
 function usage () {
-  echo "$0 [-g] [-b branch] [-p] [-h] browser version"
-  echo "  -g: pull code from git (conflicts with -p)"
-  echo "  -b: git branch to pull (default: HEAD's referant)"
-  echo "  -p: use a pre-built uproxy (conflicts with -g)"
+  echo "$0 [-p] [-h] browser version"
+  echo "  -p: path to uproxy repo"
   echo "  -h, -?: this help message"
   echo
-  echo "Without -g or -p the latest uproxy-lib NPM will be run."
+  echo "If -p is not specified then -p must be passed to run_cloud.sh and run_pair.sh."
   exit 1;
 }
 
-while getopts gb:ph? opt; do
+while getopts p:h? opt; do
   case $opt in
-    g) GIT=true ;;
-    b) BRANCH="-b $OPTARG" ;;
-    p) PREBUILT=true ;;
+    p) PREBUILT="$OPTARG" ;;
     *) usage ;;
   esac
 done
 shift $((OPTIND-1))
-
-if [ "$GIT" = true ] && [ "$PREBUILT" = true ]
-then
-  echo "cannot use both -g and -p"
-  usage
-fi
-
-if [ -n "$BRANCH" ] && [ "$GIT" = false ]
-then
-  echo "-g must be used when -b is used"
-  usage
-fi
 
 if [ $# -lt 2 ]
 then
@@ -65,24 +47,12 @@ EXPOSE 9999
 EXPOSE 5900
 EOF
 
-# load-zork.sh needs a copy of Zork in:
-#   /test/src/uproxy/build/dev/uproxy/lib/samples/zork-{chrome|firefox}app.
-# Unless -p was specified, we need to pull it down.
-if [ "$GIT" = true ]
+if [ -n "$PREBUILT" ]
 then
+  mkdir $TMP_DIR/zork
+  cp -R $PREBUILT/build/dev/uproxy/lib/samples/zork-* $TMP_DIR/zork
   cat <<EOF >> $TMP_DIR/Dockerfile
-RUN apt-get -qq install git nodejs npm
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN npm install -g grunt-cli
-RUN mkdir -p /test/src && cd /test/src && git clone https://github.com/uProxy/uproxy-lib.git $BRANCH
-RUN cd /test/src/uproxy-lib && ./setup.sh install && grunt zork
-EOF
-elif [ "$PREBUILT" = false ]
-then
-  cat <<EOF >> $TMP_DIR/Dockerfile
-RUN apt-get -qq install npm
-RUN npm install --prefix /test/src uproxy-lib
-RUN ln -s /test/src/node_modules/uproxy-lib /test/src/uproxy-lib
+COPY zork /test/zork/
 EOF
 fi
 

--- a/testing/run-scripts/run_cloud.sh
+++ b/testing/run-scripts/run_cloud.sh
@@ -24,7 +24,7 @@ SSHD_PORT=5000
 
 function usage () {
   echo "$0 [-p path] [-z zork_image] [-s sshd_image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a]"
-  echo "  -p: use a pre-built uproxy"
+  echo "  -p: path to uproxy repo"
   echo "  -z: use a specified Zork image (defaults to uproxy/zork)"
   echo "  -s: use a specified sshd image (defaults to uproxy/sshd)"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
@@ -134,7 +134,7 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   HOSTARGS=
   if [ -n "$PREBUILT" ]
   then
-    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy"
+    HOSTARGS="$HOSTARGS -v $PREBUILT/build/dev/uproxy/lib/samples:/test/zork"
   fi
   # NET_ADMIN is required to run iptables inside the container.
   # Full list of capabilities:

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -21,7 +21,7 @@ CONTAINER_PREFIX="uproxy"
 
 function usage () {
   echo "$0 [-p path] [-v] [-k] [-m mtu] [-l latency] [-s port] [-u prefix] browserspec browserspec"
-  echo "  -p: use a pre-built uproxy (conflicts with -g)"
+  echo "  -p: path to uproxy repo"
   echo "  -v: enable VNC on containers.  They will be ports 5900 and 5901."
   echo "  -k: KEEP containers after last process exits.  This is docker's --rm."
   echo "  -m MTU: set the MTU on the getter's network interface."
@@ -85,7 +85,7 @@ function run_docker () {
   fi
   if [ ! -z "$PREBUILT" ]
   then
-    HOSTARGS="$HOSTARGS -v $PREBUILT:/test/src/uproxy"
+    HOSTARGS="$HOSTARGS -v $PREBUILT/build/dev/uproxy/lib/samples:/test/zork"
   fi
   docker run $HOSTARGS $@ --name $NAME $(docker_run_args $IMAGENAME) -d $IMAGENAME /sbin/my_init -- /test/bin/load-zork.sh $RUNARGS
 }

--- a/testing/run-scripts/run_pair.sh
+++ b/testing/run-scripts/run_pair.sh
@@ -11,8 +11,6 @@ set -e
 
 source "${BASH_SOURCE%/*}/utils.sh" || (echo "cannot find utils.sh" && exit 1)
 
-GIT=false
-BRANCH=
 PREBUILT=
 VNC=false
 KEEP=false
@@ -22,9 +20,7 @@ PROXY_PORT=9999
 CONTAINER_PREFIX="uproxy"
 
 function usage () {
-  echo "$0 [-g] [-b branch] [-p path] [-v] [-k] [-m mtu] [-l latency] [-s port] [-u prefix] browserspec browserspec"
-  echo "  -g: pull code from git (conflicts with -p)"
-  echo "  -b: git branch to pull (default: HEAD's referant)"
+  echo "$0 [-p path] [-v] [-k] [-m mtu] [-l latency] [-s port] [-u prefix] browserspec browserspec"
   echo "  -p: use a pre-built uproxy (conflicts with -g)"
   echo "  -v: enable VNC on containers.  They will be ports 5900 and 5901."
   echo "  -k: KEEP containers after last process exits.  This is docker's --rm."
@@ -41,10 +37,8 @@ function usage () {
 }
 
 # TODO: replace browser-version with a Docker image name, ala run_cloud.sh
-while getopts gb:p:kvr:m:l:s:u:h? opt; do
+while getopts p:kvr:m:l:s:u:h? opt; do
   case $opt in
-    g) GIT=true ;;
-    b) BRANCH="$OPTARG" ;;
     p) PREBUILT="$OPTARG" ;;
     k) KEEP=true ;;
     v) VNC=true ;;
@@ -56,18 +50,6 @@ while getopts gb:p:kvr:m:l:s:u:h? opt; do
   esac
 done
 shift $((OPTIND-1))
-
-if [ "$GIT" = true ] && [ "$PREBUILT" = true ]
-then
-  echo "cannot use both -g and -p"
-  usage
-fi
-
-if [ -n "$BRANCH" ] && [ "$GIT" = false ]
-then
-  echo "-g must be used when -b is used"
-  usage
-fi
 
 if [ $# -lt 2 ]
 then


### PR DESCRIPTION
NPM was great while it lasted - but since we're no longer maintaining a uproxy-lib NPM that will have to change. This simplifies `image_make.sh` some: an optional argument specifying the path to your uproxy repo which, if specified, causes Zork to be bundled with the resulting image. If unspecified, you will need to pass `-p` to `run_pair.sh` and `run_cloud.sh`. Seems to work great.