### PR TITLE
use official nodejs installer for jpm

### DIFF
--- a/testing/run-scripts/gen_browser.sh
+++ b/testing/run-scripts/gen_browser.sh
@@ -63,10 +63,12 @@ EOF
 function get_firefox () {
   cat <<EOF
 RUN echo BROWSER=firefox >/etc/test.conf
-# jpm's installer requires node.
-RUN apt-get -qq install npm nodejs
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-RUN npm install jpm -g
+
+# jpm requires Node.js.
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g jpm
+
 # Firefox dependencies (apt-get install -f handles this for Chrome).
 RUN apt-get -qq install libasound2 libdbus-glib-1-2 libgtk2.0.0 libgtk-3-0
 EOF


### PR DESCRIPTION
`jpm` doesn't seem to work well anymore with the (ancient) Node.js version `apt-get` gives us. So let's just use the official installer. Works great and seems to shave ~50MB off the final image size.