### PR TITLE
Add `ip` as required command for install-cloud

### DIFF
--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-REQUIRED_COMMANDS="docker git nc"
+REQUIRED_COMMANDS="docker git nc ip"
 
 AUTOMATED=false
 UPDATE=false


### PR DESCRIPTION
the `ip` command is used when installing docker in the `run_cloud` script while not being noted as a required command.  The command does not exist on OSX machines and causes an error.

Fixes uProxy/uproxy#2598
