### PR TITLE
only install and run x for chrome and firefox

### DIFF
--- a/testing/integration/test/bin/load-zork.sh
+++ b/testing/integration/test/bin/load-zork.sh
@@ -26,14 +26,17 @@ while getopts vzh? opt; do
   esac
 done
 
-pkill Xvfb
-rm -f /tmp/.X10-lock
-export DISPLAY=:10
-Xvfb :10 -screen 0 1280x1024x24 &
-fvwm &
+if [ "$BROWSER" = "chrome" ] || [ "$BROWSER" = "firefox" ]
+then
+  pkill Xvfb
+  rm -f /tmp/.X10-lock
+  export DISPLAY=:10
+  Xvfb :10 -screen 0 1280x1024x24 &
+  fvwm &
 
-if [ "$RUNVNC" = true ]; then
-  x11vnc -display :10 -forever &
+  if [ "$RUNVNC" = true ]; then
+    x11vnc -display :10 -forever &
+  fi
 fi
 
 if [ "$IPTABLES" = true ]

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -37,15 +37,23 @@ cat <<EOF > $TMP_DIR/Dockerfile
 FROM phusion/baseimage:0.9.19
 
 RUN apt-get -qq update
-RUN apt-get -qq install wget unzip xvfb fvwm supervisor iptables x11vnc unattended-upgrades
+RUN apt-get -qq install wget unzip supervisor iptables unattended-upgrades
 
 RUN mkdir /test
 COPY test /test
 
 EXPOSE 9000
 EXPOSE 9999
+EOF
+
+# Chrome and Firefox need X.
+if [ "$BROWSER" = "chrome" ] || [ "$BROWSER" = "firefox" ]
+then
+  cat <<EOF >> $TMP_DIR/Dockerfile
+RUN apt-get install -y xvfb fvwm x11vnc
 EXPOSE 5900
 EOF
+fi
 
 if [ -n "$PREBUILT" ]
 then

--- a/testing/run-scripts/image_make.sh
+++ b/testing/run-scripts/image_make.sh
@@ -37,7 +37,7 @@ cat <<EOF > $TMP_DIR/Dockerfile
 FROM phusion/baseimage:0.9.19
 
 RUN apt-get -qq update
-RUN apt-get -qq install wget unzip supervisor iptables unattended-upgrades
+RUN apt-get -qq install wget unzip bzip2 supervisor iptables unattended-upgrades
 
 RUN mkdir /test
 COPY test /test


### PR DESCRIPTION
We can be a **lot** smarter about how we build these images but this is the big one: it cuts the size of the zork image running on Node.js to ~500MB vs. ~830MB for Firefox.