### PR TITLE
get flood server onto docker hub, with fixes

### DIFF
--- a/flood/Dockerfile
+++ b/flood/Dockerfile
@@ -2,9 +2,7 @@ FROM ubuntu:trusty
 MAINTAINER Trevor Johnston <trevj@google.com>
 
 RUN apt-get update -qq
-RUN apt-get install -y nmap pv
-
-EXPOSE 1224
+RUN apt-get install -y nmap
 
 COPY flood.sh /flood.sh
 ENTRYPOINT ["/flood.sh"]

--- a/flood/flood.sh
+++ b/flood/flood.sh
@@ -4,4 +4,4 @@
 # DO NOT CALL THIS SCRIPT DIRECTLY -- see testing/run-scripts/flood.sh
 ###
 
-ncat -l -k -p 1224 -c "dd if=/dev/zero count=1 bs=$1 status=none | pv -q -L $2"
+ncat -l -k -p 1224 -c "dd if=/dev/zero count=1 bs=$1 status=none"

--- a/testing/run-scripts/flood.sh
+++ b/testing/run-scripts/flood.sh
@@ -2,33 +2,13 @@
 
 set -e
 
-# Prints the IP of a flood server, starting one if necessary.
+# Starts a flood server and prints the IP of its container.
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: flood.sh <size of download> <max. transfer rate>"
-  echo "Examples:"
-  echo "  10MB @ 500k/sec: flood.sh 10M 500k"
-  echo "  1GB @ 1M/sec: flood.sh 1G 10M"
+if [ "$#" -ne 1 ]; then
+  echo "Usage: flood.sh <size of download, e.g. 128M>"
   exit 1
 fi
 
-# Build an image if none already exists.
-if ! docker images | grep uproxy/flood >/dev/null; then
-  docker build -t uproxy/flood ${BASH_SOURCE%/*}/../../flood > /dev/null
-fi
+CONTAINER_ID=`docker run -d uproxy/flood $1`
 
-# Kill the current container, if any.
-# TODO: Skip this if the running container's args match.
-if docker ps -a | grep uproxy-flood >/dev/null; then
-  docker rm -f uproxy-flood > /dev/null
-fi
-
-docker run -d -p 1224:1224 --name uproxy-flood uproxy/flood $1 $2 > /dev/null
-
-# Wait until the service is actually up; because we use -d, docker wait
-# is unavailable and we must probe the port manually.
-CONTAINER_IP=`docker inspect --format '{{ .NetworkSettings.IPAddress }}' uproxy-flood`
-
-while ! nc -z $CONTAINER_IP 1224; do sleep 0.1; done
-
-echo "$CONTAINER_IP"
+docker inspect --format '{{ .NetworkSettings.IPAddress }}' $CONTAINER_ID

--- a/testing/run-scripts/release.py
+++ b/testing/run-scripts/release.py
@@ -32,12 +32,11 @@ known_small_md5sum = subprocess.check_output(
     universal_newlines=True).strip()
 print('** small download known md5sum: ' + known_small_md5sum)
 
-# Where is flood server?
+# Start a flood server.
 FLOOD_SIZE_MB = 1
-FLOOD_MAX_SPEED = '5M'
-flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M',
-    FLOOD_MAX_SPEED], universal_newlines=True).strip()
-print('** using flood server at ' + str(flood_ip))
+flood_ip = subprocess.check_output(['./flood.sh', str(FLOOD_SIZE_MB) + 'M'],
+    universal_newlines=True).strip()
+print('** flood server: ' + flood_ip)
 
 subprocess.call('nc ' + flood_ip + ' 1224 > /tmp/nc', shell=True)
 known_large_md5sum = subprocess.check_output(


### PR DESCRIPTION
I wanted to get our flood server image onto Docker Hub and fell into a - useful, admittedly - rabbit hole.

TL;DR: because `dd if=/dev/zero count=1 bs=100M` takes **vastly** longer to run than `dd if=/dev/zero count=1 bs=100M > /dev/null` we haven't always been testing our proxy at its limits

Summary of changes:
 * do not build flood server on-demand
 * remove the rate limiting stuff (`pv`) because it's been a long time since we didn't implement back-pressure
 * consume the pipe as fast as possible

I ran a bunch of benchmarks: Chrome, Firefox, Node.js, with and without obfuscation, with and without latency between peers, etc. etc.

What surprised me:
 * Chrome is a beast. Unobfuscated, my system - a 3.5Ghz Xeon E5 - can push 15MB/sec through Zork. **That's 3x Firefox and 10x Node.js.**
 * Obfuscation changes this: **Firefox pushes 1.5x as much per second as Chrome** (1.8Mb/sec vs. 1.2Mb/sec)
 * Latency between peers affects Node.js very badly: at 150ms between peers, it only pushes 1/3 as much data per second as Chrome or Firefox. I wonder if this is the same poor buffer handling at the SCTP layer as old versions of Firefox?

Full results:

### no obfuscation
#### 0ms latency
chrome,14611
firefox,5781
node,1523

#### 150ms latency
chrome,604
firefox,612
node,225

### caesar
#### 0ms latency
chrome,1289
firefox,1772
node,872

#### 150ms latency
chrome,535
firefox,532
node,192

### rc4
#### 0ms latency
chrome,1208
firefox,1814
node,817

#### 150ms latency
chrome,529
firefox,530
node,195