### PR TITLE
Write Quiver logs from docker container to syslogs

### DIFF
--- a/install-quiver.sh
+++ b/install-quiver.sh
@@ -26,7 +26,7 @@ do_install() {
     curl -fsSL https://get.docker.com/ | sh
   fi
 
-  docker run --restart=always --name uproxy-quiver -d -p 80:3000 uproxy/quiver
+  docker run --restart=always --name uproxy-quiver --log-driver=syslog --log-tag=quiver -d -p 80:3000 uproxy/quiver
 }
 
 # Wrapped in a function for some protection against half-downloads.

--- a/install-quiver.sh
+++ b/install-quiver.sh
@@ -26,7 +26,7 @@ do_install() {
     curl -fsSL https://get.docker.com/ | sh
   fi
 
-  docker run --restart=always --name uproxy-quiver --log-driver=syslog --log-tag=quiver -d -p 80:3000 uproxy/quiver
+  docker run --restart=always --log-driver=syslog --log-opt tag=quiver --name uproxy-quiver -d -p 80:3000 uproxy/quiver
 }
 
 # Wrapped in a function for some protection against half-downloads.


### PR DESCRIPTION
Write Quiver logs from docker container to syslogs, so that we can easily grep through them as before, and they will rotate/zip as they grow too long
