### PR TITLE
workaround for frozen chrome on startup

### DIFF
--- a/testing/integration/test/etc/supervisord-chrome.conf
+++ b/testing/integration/test/etc/supervisord-chrome.conf
@@ -1,4 +1,8 @@
 [supervisord]
+# Without this, Chrome frequently hangs on startup.
+# We use a workaround suggested in this Selenium issue:
+#   https://github.com/SeleniumHQ/docker-selenium/issues/87#issuecomment-187580115
+environment=DBUS_SESSION_BUS_ADDRESS="/dev/null"
 
 [program:chrome]
 command=google-chrome --user-data-dir=/tmp/chrome-data --load-and-launch-app=/test/zork/zork-chromeapp --no-default-browser-check --no-first-run


### PR DESCRIPTION
With this, I'm **finally** able to reliably run `release.py` on my system:
https://github.com/uProxy/uproxy/issues/2174
