### PR TITLE
make the flood server reliable and smaller

### DIFF
--- a/flood/Dockerfile
+++ b/flood/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:trusty
-MAINTAINER Trevor Johnston <trevj@google.com>
+FROM alpine:edge
 
-RUN apt-get update -qq
-RUN apt-get install -y nmap
+RUN apk update
+RUN apk add socat
 
 COPY flood.sh /flood.sh
 ENTRYPOINT ["/flood.sh"]

--- a/flood/flood.sh
+++ b/flood/flood.sh
@@ -1,7 +1,2 @@
-#!/bin/bash
-
-###
-# DO NOT CALL THIS SCRIPT DIRECTLY -- see testing/run-scripts/flood.sh
-###
-
-ncat -l -k -p 1224 -c "dd if=/dev/zero count=1 bs=$1 status=none"
+#!/bin/sh
+socat -U TCP-LISTEN:1224,reuseaddr,fork EXEC:"dd if=/dev/zero bs=$1 count=1"


### PR DESCRIPTION
Two things:
1. move to Alpine (cuts image size ~90%, down to ~10M)
1. use `socat` rather than `ncat`

The second took a **lot** of trial and error: it seems like there's some weird issue with `ncat` on Docker. If I run this command in a terminal:
```bash
ncat -l -k -p 1224 -c "dd if=/dev/zero count=1 bs=10M"
```
And run this in another terminal:
```bash
while true; do nc localhost 1224 | wc; done
```
The second command will show the expected number of bytes transferred 100% of the time. Never fails.

However, if instead I repeat the two commands, this time:
1. run the first command inside a Docker container
1. make the second command connect to the container's IP (find this with `docker inspect`)

Then I often **do not** receive the expected number of bytes. I guess-timate ~30% of the time the response is truncated.

At first I suspected a Docker issue but then I found that when I replace `ncat` with a HTTP transfer or some other tool like `socat`, I get the expected number of bytes every time. Since `socat` is small and universal, I chose `socat`.